### PR TITLE
fix: Copy .npmrc to Docker build context for npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:20-alpine AS frontend-builder
 WORKDIR /src/frontend
 
 # Copy package files for frontend
-COPY frontend/package.json frontend/package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json frontend/.npmrc ./
 RUN npm ci --quiet
 
 # Copy frontend source and configuration


### PR DESCRIPTION
Docker build was failing because .npmrc (with legacy-peer-deps=true) wasn't being copied into the build container before running npm ci.

This caused the same React 19 / @testing-library/react peer dependency conflict that we fixed locally.

Change: Added frontend/.npmrc to the COPY command in Dockerfile before npm ci runs.

This ensures npm respects the legacy-peer-deps setting during Docker builds.

#### Description
A few sentences describing the overall goals of the pull request's commits.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes


#### Database Migration
YES - ###


#### Issues Fixed or Closed by this PR
* Closes #

