### PR TITLE
Team based filtering for league add/edit

### DIFF
--- a/frontend/src/components/AddLeagueModal.tsx
+++ b/frontend/src/components/AddLeagueModal.tsx
@@ -303,6 +303,7 @@ export default function AddLeagueModal({ league, isOpen, onClose, onAdd, isAddin
       // Reset state for new league
       setSelectedTeamIds(new Set());
       setSelectAll(false);
+      setSearchQuery('');
       setMonitorType('Future');
       setQualityProfileId(qualityProfiles.length > 0 ? qualityProfiles[0].id : null);
       setSearchForMissingEvents(false);


### PR DESCRIPTION
Some of the leagues have an unwieldy amount of teams, like NCAA Football/Basketball (multiple hundreds...). This PR introduces a search based filter when the amount of teams is greater than 25. If a team has already been selected but does not match the search filter it is still visible in the results.

Current
<img width="1179" height="1233" alt="image" src="https://github.com/user-attachments/assets/9f3c1b25-ed4c-434f-a586-26191b44b812" />

Proposed
<img width="1334" height="1262" alt="image" src="https://github.com/user-attachments/assets/84286a7d-e056-4109-8cd1-152cff395c7c" />
<img width="1382" height="1196" alt="image" src="https://github.com/user-attachments/assets/6423e9d4-9976-4bca-957b-b35c7be460c5" />
