### PR TITLE
Fix team sport release matching - require both teams, add NBA/NFL/MLB teams to dictionary.

### DIFF
--- a/src/Services/ReleaseMatchingService.cs
+++ b/src/Services/ReleaseMatchingService.cs
@@ -96,6 +96,118 @@ public class ReleaseMatchingService
         // Add more as needed
     };
 
+    // Team name variations: alternate ways teams are referenced in releases
+    // Key: official team name (normalized to lowercase), Value: alternate names to check
+    private static readonly Dictionary<string, string[]> TeamNameVariations = new(StringComparer.OrdinalIgnoreCase)
+    {
+      // NBA Teams - Handle common release naming variations
+      // Los Angeles teams often abbreviated to "LA"
+      { "los angeles clippers", new[] { "la clippers", "clippers" } },
+      { "los angeles lakers", new[] { "la lakers", "lakers" } },
+      // Golden State often abbreviated to "GS"
+      { "golden state warriors", new[] { "gs warriors", "warriors" } },
+      // Oklahoma City often abbreviated to "OKC"
+      { "oklahoma city thunder", new[] { "okc thunder", "okc", "thunder" } },
+      // New York often abbreviated to "NY"
+      { "new york knicks", new[] { "ny knicks", "knicks" } },
+      // New Orleans often abbreviated to "NO" or "NOLA"
+      { "new orleans pelicans", new[] { "no pelicans", "nola pelicans", "pelicans" } },
+      // San Antonio often abbreviated to "SA"
+      { "san antonio spurs", new[] { "sa spurs", "spurs" } },
+      // Portland Trail Blazers - handle "Trailblazers" (one word) vs "Trail Blazers" (two words)
+      { "portland trail blazers", new[] { "portland trailblazers", "trailblazers", "trail blazers", "blazers" } },
+      // Philadelphia 76ers - handle numeric variations
+      { "philadelphia 76ers", new[] { "philly 76ers", "76ers", "sixers" } },
+      // Other teams - just the short name for matching flexibility
+      { "atlanta hawks", new[] { "hawks" } },
+      { "boston celtics", new[] { "celtics" } },
+      { "brooklyn nets", new[] { "nets" } },
+      { "charlotte hornets", new[] { "hornets" } },
+      { "chicago bulls", new[] { "bulls" } },
+      { "cleveland cavaliers", new[] { "cavaliers", "cavs" } },
+      { "dallas mavericks", new[] { "mavericks", "mavs" } },
+      { "denver nuggets", new[] { "nuggets" } },
+      { "detroit pistons", new[] { "pistons" } },
+      { "houston rockets", new[] { "rockets" } },
+      { "indiana pacers", new[] { "pacers" } },
+      { "memphis grizzlies", new[] { "grizzlies" } },
+      { "miami heat", new[] { "heat" } },
+      { "milwaukee bucks", new[] { "bucks" } },
+      { "minnesota timberwolves", new[] { "timberwolves", "t-wolves", "wolves" } },
+      { "orlando magic", new[] { "magic" } },
+      { "phoenix suns", new[] { "suns" } },
+      { "sacramento kings", new[] { "kings" } },
+      { "toronto raptors", new[] { "raptors" } },
+      { "utah jazz", new[] { "jazz" } },
+      { "washington wizards", new[] { "wizards" } },
+
+      // NFL Teams - Handle common release naming variations
+      { "arizona cardinals", new[] { "cardinals" } },
+      { "atlanta falcons", new[] { "falcons" } },
+      { "baltimore ravens", new[] { "ravens" } },
+      { "buffalo bills", new[] { "bills" } },
+      { "carolina panthers", new[] { "panthers" } },
+      { "chicago bears", new[] { "bears" } },
+      { "cincinnati bengals", new[] { "bengals" } },
+      { "cleveland browns", new[] { "browns" } },
+      { "dallas cowboys", new[] { "cowboys" } },
+      { "denver broncos", new[] { "broncos" } },
+      { "detroit lions", new[] { "lions" } },
+      { "green bay packers", new[] { "packers", "gb packers" } },
+      { "houston texans", new[] { "texans" } },
+      { "indianapolis colts", new[] { "colts" } },
+      { "jacksonville jaguars", new[] { "jaguars", "jags" } },
+      { "kansas city chiefs", new[] { "chiefs", "kc chiefs" } },
+      { "las vegas raiders", new[] { "raiders", "lv raiders" } },
+      { "los angeles chargers", new[] { "chargers", "la chargers" } },
+      { "los angeles rams", new[] { "rams", "la rams" } },
+      { "miami dolphins", new[] { "dolphins" } },
+      { "minnesota vikings", new[] { "vikings" } },
+      { "new england patriots", new[] { "patriots", "ne patriots" } },
+      { "new orleans saints", new[] { "saints", "no saints" } },
+      { "new york giants", new[] { "giants", "ny giants" } },
+      { "new york jets", new[] { "jets", "ny jets" } },
+      { "philadelphia eagles", new[] { "eagles" } },
+      { "pittsburgh steelers", new[] { "steelers" } },
+      { "san francisco 49ers", new[] { "49ers", "niners", "sf 49ers" } },
+      { "seattle seahawks", new[] { "seahawks" } },
+      { "tampa bay buccaneers", new[] { "buccaneers", "bucs" } },
+      { "tennessee titans", new[] { "titans" } },
+      { "washington commanders", new[] { "commanders" } },
+
+      // MLB Teams - Handle common release naming variations
+      { "arizona diamondbacks", new[] { "diamondbacks", "d-backs", "dbacks" } },
+      { "atlanta braves", new[] { "braves" } },
+      { "baltimore orioles", new[] { "orioles", "o's" } },
+      { "boston red sox", new[] { "red sox", "redsox", "bosox" } },
+      { "chicago cubs", new[] { "cubs", "cubbies" } },
+      { "chicago white sox", new[] { "white sox", "whitesox", "chisox" } },
+      { "cincinnati reds", new[] { "reds", "redlegs" } },
+      { "cleveland guardians", new[] { "guardians", "guards" } },
+      { "colorado rockies", new[] { "rockies", "rox" } },
+      { "detroit tigers", new[] { "tigers" } },
+      { "houston astros", new[] { "astros", "stros" } },
+      { "kansas city royals", new[] { "royals" } },
+      { "los angeles angels", new[] { "angels", "la angels", "halos" } },
+      { "los angeles dodgers", new[] { "dodgers", "la dodgers" } },
+      { "miami marlins", new[] { "marlins" } },
+      { "milwaukee brewers", new[] { "brewers", "brew crew" } },
+      { "minnesota twins", new[] { "twins" } },
+      { "new york mets", new[] { "mets", "ny mets" } },
+      { "new york yankees", new[] { "yankees", "yanks", "ny yankees" } },
+      { "oakland athletics", new[] { "athletics", "a's", "as" } },
+      { "philadelphia phillies", new[] { "phillies", "phils" } },
+      { "pittsburgh pirates", new[] { "pirates", "buccos", "bucs" } },
+      { "san diego padres", new[] { "padres", "pads" } },
+      { "san francisco giants", new[] { "giants", "sf giants" } },
+      { "seattle mariners", new[] { "mariners", "m's" } },
+      { "st. louis cardinals", new[] { "cardinals", "cards", "stl cardinals" } },
+      { "tampa bay rays", new[] { "rays", "tb rays" } },
+      { "texas rangers", new[] { "rangers", "tex rangers" } },
+      { "toronto blue jays", new[] { "blue jays", "bluejays", "jays" } },
+      { "washington nationals", new[] { "nationals", "nats" } },
+    };
+
     public ReleaseMatchingService(
         ILogger<ReleaseMatchingService> logger,
         SportsFileNameParser sportsParser,
@@ -145,14 +257,23 @@ public class ReleaseMatchingService
         var normalizedRelease = NormalizeTitle(release.Title);
         var normalizedEvent = NormalizeTitle(evt.Title);
 
-        // Also check if release matches any location variations of the event title
-        // This handles cases like "Mexico Grand Prix" matching "Mexico City Grand Prix"
-        var isLocationVariationMatch = SearchNormalizationService.IsReleaseMatch(release.Title, evt.Title);
-        if (isLocationVariationMatch && !normalizedRelease.Contains(normalizedEvent, StringComparison.OrdinalIgnoreCase))
+        // Location variation matching is ONLY useful for non-team sports (F1, UFC, etc.)
+        // where the event title contains location names (e.g., "Mexico Grand Prix" vs "Mexican Grand Prix")
+        // For team sports (NBA, NFL, etc.), this check causes false positives because
+        // team city names like "Los Angeles" trigger location aliases inappropriately
+        var isTeamSport = evt.HomeTeam != null && evt.AwayTeam != null;
+
+        if (!isTeamSport)
         {
-            result.Confidence += 15;
-            result.MatchReasons.Add("Location/naming variation match");
-            _logger.LogDebug("[Release Matching] Location variation match: release uses alternate location name");
+            // Check if release matches any location variations of the event title
+            // This handles cases like "Mexico Grand Prix" matching "Mexico City Grand Prix"
+            var isLocationVariationMatch = SearchNormalizationService.IsReleaseMatch(release.Title, evt.Title);
+            if (isLocationVariationMatch && !normalizedRelease.Contains(normalizedEvent, StringComparison.OrdinalIgnoreCase))
+            {
+                result.Confidence += 15;
+                result.MatchReasons.Add("Location/naming variation match");
+                _logger.LogDebug("[Release Matching] Location variation match: release uses alternate location name");
+            }
         }
 
         // VALIDATION 1: Event number match (UFC 299, Bellator 300, etc.)
@@ -173,21 +294,31 @@ public class ReleaseMatchingService
         }
 
         // VALIDATION 2: Team names match (for team sports)
+        // For "Team A vs Team B" events, BOTH teams must be present in the release
+        // Finding only one team likely means it's a different game involving that team
         if (evt.HomeTeam != null && evt.AwayTeam != null)
         {
             var teamMatch = ValidateTeamNames(release.Title, evt.HomeTeam, evt.AwayTeam);
             if (teamMatch >= 2)
             {
+                // Both teams found - strong positive match
                 result.Confidence += 35;
                 result.MatchReasons.Add("Both team names found");
             }
             else if (teamMatch == 1)
             {
-                result.Confidence += 15;
-                result.MatchReasons.Add("One team name found");
+                // Only one team found - this is likely a DIFFERENT game involving that team
+                // e.g., searching for "Clippers vs Nuggets" but release is "Thunder vs Nuggets"
+                // This should be a hard rejection to prevent downloading wrong games
+                result.Confidence -= 100;
+                result.IsHardRejection = true;
+                result.Rejections.Add("Only one team found - likely different game");
+                _logger.LogDebug("[Release Matching] Hard rejection: only one team found for team vs team event: '{Release}'",
+                    release.Title);
             }
             else
             {
+                // No teams found at all
                 result.Confidence -= 20;
                 result.Rejections.Add("Team names not found in release");
             }
@@ -569,25 +700,45 @@ public class ReleaseMatchingService
     }
 
     /// <summary>
-    /// Check if release title contains a team name (or its abbreviation)
+    /// Check if release title contains a team name (or its abbreviation/variation)
     /// </summary>
     private bool ContainsTeamName(string normalizedRelease, Team team)
     {
-        // Check full name
-        if (normalizedRelease.Contains(NormalizeTitle(team.Name), StringComparison.OrdinalIgnoreCase))
+        var normalizedName = NormalizeTitle(team.Name);
+
+        // Check full name (e.g., "Los Angeles Clippers")
+        if (normalizedRelease.Contains(normalizedName, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        // Check short name
+        // Check short name from database (e.g., "Clippers")
         if (!string.IsNullOrEmpty(team.ShortName) &&
             normalizedRelease.Contains(NormalizeTitle(team.ShortName), StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
 
-        // Check common abbreviations
-        var normalizedName = NormalizeTitle(team.Name);
+        // Check team name variations (e.g., "LA Clippers" for "Los Angeles Clippers")
+        foreach (var (officialName, variations) in TeamNameVariations)
+        {
+            if (normalizedName.Contains(officialName, StringComparison.OrdinalIgnoreCase) ||
+                officialName.Contains(normalizedName, StringComparison.OrdinalIgnoreCase))
+            {
+                // This team matches - check if any variation appears in release
+                foreach (var variation in variations)
+                {
+                    // Use word boundary matching to avoid partial matches
+                    var normalizedVariation = NormalizeTitle(variation);
+                    if (Regex.IsMatch(normalizedRelease, $@"\b{Regex.Escape(normalizedVariation)}\b", RegexOptions.IgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Check common abbreviations (e.g., "LAC" for Clippers)
         foreach (var (abbrev, fullNames) in TeamAbbreviations)
         {
             if (fullNames.Any(fn => normalizedName.Contains(fn, StringComparison.OrdinalIgnoreCase)))
@@ -716,7 +867,7 @@ public class ReleaseMatchingService
         // Convert word numbers to digits (for F1 "Free Practice Three" vs "Free Practice 3")
         normalized = ConvertWordNumbersToDigits(normalized);
 
-        // Remove diacritics (São Paulo → Sao Paulo, München → Munchen)
+        // Remove diacritics (SÃ£o Paulo â†’ Sao Paulo, MÃ¼nchen â†’ Munchen)
         normalized = SearchNormalizationService.RemoveDiacritics(normalized);
 
         // Remove extra whitespace


### PR DESCRIPTION


Releases containing only one of two required teams were incorrectly matching. For example, searching for "LA Clippers vs Denver Nuggets" would match "Oklahoma City Thunder vs Denver Nuggets" because one of the teams was found.

Added

    Hard reject single-team matches: Changed from +15 confidence to -100 with IsHardRejection = true
    Disabled location variation for team sports: Prevents city names like "Los Angeles" triggering false positives from F1-style location matching
    Added team name variations: Comprehensive dictionary for NBA, NFL, and MLB teams to recognize short names like "Patriots" → "New England Patriots" etc

Testing...
Verified across multiple sports:

    NBA: "LA Clippers vs Golden State Warriors" - matches correctly, rejects wrong games
    NFL: "New England Patriots vs Miami Dolphins" - "Dolphins.Vs.Patriots" now matches with "Both team names found"
    MLB: "Miami Marlins vs New York Mets" - works correctly
    F1: Location variation matching still works for motorsport

