### PR TITLE
Add .strm to supported video file extensions

### DIFF
--- a/src/Services/FileImportService.cs
+++ b/src/Services/FileImportService.cs
@@ -23,7 +23,7 @@ public class FileImportService : IFileImportService
     private readonly ILogger<FileImportService> _logger;
 
     // Supported video file extensions
-    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts" };
+    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts", ".strm" };
 
     public FileImportService(
         SportarrDbContext db,

--- a/src/Services/ImportService.cs
+++ b/src/Services/ImportService.cs
@@ -21,7 +21,7 @@ public class ImportService
     private readonly ILogger<ImportService> _logger;
 
     // Video file extensions to look for
-    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".m4v", ".mov", ".wmv", ".mpg", ".mpeg" };
+    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".m4v", ".mov", ".wmv", ".mpg", ".mpeg", ".strm" };
 
     public ImportService(
         SportarrDbContext db,

--- a/src/Services/LibraryImportService.cs
+++ b/src/Services/LibraryImportService.cs
@@ -20,7 +20,7 @@ public class LibraryImportService
     private readonly ConfigService _configService;
     private readonly TheSportsDBClient _theSportsDBClient;
 
-    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".m4v", ".mov", ".wmv", ".ts", ".webm", ".flv" };
+    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".m4v", ".mov", ".wmv", ".ts", ".webm", ".flv", ".strm" };
 
     public LibraryImportService(
         SportarrDbContext db,

--- a/src/Services/PackImportService.cs
+++ b/src/Services/PackImportService.cs
@@ -22,7 +22,7 @@ public class PackImportService
     private readonly ILogger<PackImportService> _logger;
 
     // Supported video file extensions
-    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts" };
+    private static readonly string[] VideoExtensions = { ".mkv", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts", ".strm" };
 
     public PackImportService(
         SportarrDbContext db,


### PR DESCRIPTION
This enables https://github.com/nzbdav-dev/nzbdav support by recognising .strm files as valid video files. It does not integrate perfectly with nzbdav, but it works enough to do the job.