### PR TITLE
Fix Add Teams rendering issues and implement spacious and compact standard views

### DIFF
--- a/frontend/src/components/ColumnPicker.tsx
+++ b/frontend/src/components/ColumnPicker.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline';
+
+interface ColumnDef {
+  key: string;
+  label: string;
+  alwaysVisible?: boolean;
+}
+
+interface ColumnPickerProps {
+  columns: ColumnDef[];
+  isVisible: (col: string) => boolean;
+  onToggle: (col: string) => void;
+}
+
+export default function ColumnPicker({
+  columns,
+  isVisible,
+  onToggle,
+}: ColumnPickerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+        title="Choose visible columns"
+        className={`flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-sm transition-colors ${
+          open
+            ? 'border-blue-500/50 bg-blue-600/20 text-white'
+            : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600 hover:text-white'
+        }`}
+      >
+        <AdjustmentsHorizontalIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">Columns</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-52 overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-xl">
+          <div className="border-b border-gray-700 px-3 py-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
+              Visible Columns
+            </p>
+          </div>
+          <div className="max-h-72 overflow-y-auto p-1">
+            {columns.map((column) => (
+              <label
+                key={column.key}
+                className={`flex cursor-pointer items-center gap-2.5 rounded px-2 py-1.5 transition-colors ${
+                  column.alwaysVisible ? 'cursor-not-allowed opacity-50' : 'hover:bg-gray-800'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isVisible(column.key)}
+                  onChange={() => {
+                    if (!column.alwaysVisible) {
+                      onToggle(column.key);
+                    }
+                  }}
+                  disabled={column.alwaysVisible}
+                  className="h-3.5 w-3.5 rounded border-gray-600 bg-gray-700 text-red-600 focus:ring-red-500"
+                />
+                <span className="text-sm text-gray-300">{column.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CompactTableFrame.tsx
+++ b/frontend/src/components/CompactTableFrame.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+interface CompactTableFrameProps {
+  children: ReactNode;
+  controls?: ReactNode;
+  className?: string;
+  tableClassName?: string;
+}
+
+export default function CompactTableFrame({
+  children,
+  controls,
+  className = '',
+  tableClassName = '',
+}: CompactTableFrameProps) {
+  return (
+    <div className={className}>
+      {controls && <div className="mb-1 flex justify-end">{controls}</div>}
+      <div className="overflow-x-auto">
+        <table className={`w-full ${tableClassName}`.trim()}>{children}</table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SortableFilterableHeader.tsx
+++ b/frontend/src/components/SortableFilterableHeader.tsx
@@ -1,0 +1,83 @@
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  FunnelIcon,
+} from '@heroicons/react/24/outline';
+
+interface SortableFilterableHeaderProps {
+  col: string;
+  label: string;
+  sortCol: string;
+  sortDir: 'asc' | 'desc';
+  onSort: (col: string) => void;
+  colFilters: Record<string, string>;
+  activeFilterCol: string | null;
+  onFilterChange: (col: string, value: string) => void;
+  onFilterToggle: (col: string) => void;
+  className?: string;
+  centered?: boolean;
+}
+
+export default function SortableFilterableHeader({
+  col,
+  label,
+  sortCol,
+  sortDir,
+  onSort,
+  colFilters,
+  activeFilterCol,
+  onFilterChange,
+  onFilterToggle,
+  className = 'px-3 py-1.5',
+  centered = false,
+}: SortableFilterableHeaderProps) {
+  const isActive = sortCol === col;
+  const hasFilter = Boolean(colFilters[col]);
+
+  return (
+    <th
+      className={`${className} cursor-pointer select-none hover:bg-gray-800/30`}
+      onClick={() => onSort(col)}
+    >
+      <div className={`flex items-center gap-1${centered ? ' justify-center' : ''}`}>
+        <span>{label}</span>
+        {isActive ? (
+          sortDir === 'asc' ? (
+            <ChevronUpIcon className="h-3 w-3 flex-shrink-0" />
+          ) : (
+            <ChevronDownIcon className="h-3 w-3 flex-shrink-0" />
+          )
+        ) : (
+          <span className="h-3 w-3 flex-shrink-0 opacity-0" />
+        )}
+        <button
+          type="button"
+          className={`flex-shrink-0 rounded p-0.5 ${
+            hasFilter
+              ? 'text-amber-400 hover:bg-gray-700'
+              : 'text-gray-600 hover:bg-gray-700 hover:text-gray-400'
+          }`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onFilterToggle(col);
+          }}
+          title="Filter"
+        >
+          <FunnelIcon className="h-3 w-3" />
+        </button>
+      </div>
+      {activeFilterCol === col && (
+        <div className="mt-1" onClick={(event) => event.stopPropagation()}>
+          <input
+            autoFocus
+            type="text"
+            value={colFilters[col] || ''}
+            onChange={(event) => onFilterChange(col, event.target.value)}
+            placeholder="Filter..."
+            className="w-full rounded border border-gray-600 bg-gray-900 px-1.5 py-0.5 text-xs font-normal normal-case text-white"
+          />
+        </div>
+      )}
+    </th>
+  );
+}

--- a/frontend/src/hooks/useColumnVisibility.ts
+++ b/frontend/src/hooks/useColumnVisibility.ts
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+export function useColumnVisibility<T extends string>(
+  localStorageKey: string,
+  defaults: Record<T, boolean>,
+  alwaysVisible: T[] = []
+): {
+  colVisibility: Record<T, boolean>;
+  toggleCol: (col: T) => void;
+  isVisible: (col: T) => boolean;
+} {
+  const [colVisibility, setColVisibility] = useState<Record<T, boolean>>(() => {
+    if (typeof window === 'undefined') {
+      return { ...defaults };
+    }
+
+    try {
+      const saved = window.localStorage.getItem(localStorageKey);
+      if (!saved) {
+        return { ...defaults };
+      }
+
+      const parsed = JSON.parse(saved) as Partial<Record<T, boolean>>;
+      const merged = { ...defaults, ...parsed } as Record<T, boolean>;
+      alwaysVisible.forEach((col) => {
+        merged[col] = true;
+      });
+      return merged;
+    } catch {
+      return { ...defaults };
+    }
+  });
+
+  const toggleCol = (col: T) => {
+    if (alwaysVisible.includes(col)) {
+      return;
+    }
+
+    setColVisibility((current) => {
+      const next = { ...current, [col]: !current[col] };
+
+      try {
+        window.localStorage.setItem(localStorageKey, JSON.stringify(next));
+      } catch {
+        // Ignore storage errors.
+      }
+
+      return next;
+    });
+  };
+
+  return {
+    colVisibility,
+    toggleCol,
+    isVisible: (col: T) => colVisibility[col] ?? true,
+  };
+}

--- a/frontend/src/hooks/useCompactView.ts
+++ b/frontend/src/hooks/useCompactView.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { useUISettings } from './useUISettings';
+
+const COMPACT_VIEW_BREAKPOINT = 1280;
+
+function getIsWideScreen(breakpoint: number): boolean {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  return window.innerWidth >= breakpoint;
+}
+
+export function useIsWideScreen(breakpoint = COMPACT_VIEW_BREAKPOINT): boolean {
+  const [wideScreen, setWideScreen] = useState(() => getIsWideScreen(breakpoint));
+
+  useEffect(() => {
+    const onResize = () => setWideScreen(getIsWideScreen(breakpoint));
+    window.addEventListener('resize', onResize);
+
+    return () => window.removeEventListener('resize', onResize);
+  }, [breakpoint]);
+
+  return wideScreen;
+}
+
+export function useCompactView(): boolean {
+  const { eventViewMode, loading } = useUISettings();
+  const wideScreen = useIsWideScreen();
+
+  if (loading) {
+    return wideScreen;
+  }
+
+  if (eventViewMode === 'compact') {
+    return true;
+  }
+
+  if (eventViewMode === 'spacious') {
+    return false;
+  }
+
+  return wideScreen;
+}

--- a/frontend/src/hooks/useTableSortFilter.ts
+++ b/frontend/src/hooks/useTableSortFilter.ts
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+export interface TableSortFilterState {
+  sortCol: string;
+  sortDir: 'asc' | 'desc';
+  colFilters: Record<string, string>;
+  activeFilterCol: string | null;
+  handleColSort: (col: string) => void;
+  onFilterChange: (col: string, value: string) => void;
+  onFilterToggle: (col: string) => void;
+}
+
+export function applyTableSortFilter<T>(
+  items: T[],
+  colFilters: Record<string, string>,
+  sortCol: string,
+  sortDir: 'asc' | 'desc',
+  fieldExtractor: (col: string, item: T) => string
+): T[] {
+  let result = items;
+
+  Object.entries(colFilters).forEach(([col, value]) => {
+    if (!value.trim()) {
+      return;
+    }
+
+    const normalizedValue = value.toLowerCase();
+    result = result.filter((item) =>
+      fieldExtractor(col, item).toLowerCase().includes(normalizedValue)
+    );
+  });
+
+  if (!sortCol) {
+    return result;
+  }
+
+  return [...result].sort((left, right) => {
+    const comparison = fieldExtractor(sortCol, left).localeCompare(
+      fieldExtractor(sortCol, right),
+      undefined,
+      { numeric: true }
+    );
+
+    return sortDir === 'asc' ? comparison : -comparison;
+  });
+}
+
+export function useTableSortFilter(initialSortCol: string): TableSortFilterState {
+  const [sortCol, setSortCol] = useState(initialSortCol);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [colFilters, setColFilters] = useState<Record<string, string>>({});
+  const [activeFilterCol, setActiveFilterCol] = useState<string | null>(null);
+
+  const handleColSort = (col: string) => {
+    if (sortCol === col) {
+      setSortDir((current) => (current === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+
+    setSortCol(col);
+    setSortDir('asc');
+  };
+
+  const onFilterChange = (col: string, value: string) => {
+    setColFilters((current) => ({ ...current, [col]: value }));
+  };
+
+  const onFilterToggle = (col: string) => {
+    setActiveFilterCol((current) => (current === col ? null : col));
+  };
+
+  return {
+    sortCol,
+    sortDir,
+    colFilters,
+    activeFilterCol,
+    handleColSort,
+    onFilterChange,
+    onFilterToggle,
+  };
+}

--- a/frontend/src/hooks/useUISettings.ts
+++ b/frontend/src/hooks/useUISettings.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '../utils/api';
+
+interface UISettings {
+  eventViewMode?: string;
+  timeZone?: string;
+}
+
+export const UI_SETTINGS_QUERY_KEY = ['ui-settings'] as const;
+
+async function fetchUISettings(): Promise<UISettings | null> {
+  try {
+    const response = await apiGet('/api/settings');
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json();
+    if (!data.uiSettings) {
+      return null;
+    }
+
+    return JSON.parse(data.uiSettings) as UISettings;
+  } catch {
+    return null;
+  }
+}
+
+export function useUISettings(): {
+  eventViewMode: string;
+  timezone: string | null;
+  loading: boolean;
+} {
+  const { data, isLoading } = useQuery({
+    queryKey: UI_SETTINGS_QUERY_KEY,
+    queryFn: fetchUISettings,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    eventViewMode: data?.eventViewMode ?? 'auto',
+    timezone: data?.timeZone ?? null,
+    loading: isLoading,
+  };
+}

--- a/frontend/src/pages/TeamsPage.tsx
+++ b/frontend/src/pages/TeamsPage.tsx
@@ -1,22 +1,28 @@
-import { useState, useMemo, useRef } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  MagnifyingGlassIcon,
-  GlobeAltIcon,
-  UserGroupIcon,
+  ArrowPathIcon,
   CheckCircleIcon,
+  CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  GlobeAltIcon,
+  MagnifyingGlassIcon,
   PlusIcon,
-  ArrowPathIcon,
-  CheckIcon,
   TrashIcon,
+  UserGroupIcon,
 } from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
 import apiClient from '../api/client';
-import type { Team, FollowedTeam, DiscoveredLeague, QualityProfile } from '../types';
+import ColumnPicker from '../components/ColumnPicker';
+import CompactTableFrame from '../components/CompactTableFrame';
+import PageHeader from '../components/PageHeader';
+import SortableFilterableHeader from '../components/SortableFilterableHeader';
+import { useColumnVisibility } from '../hooks/useColumnVisibility';
+import { useCompactView, useIsWideScreen } from '../hooks/useCompactView';
+import { applyTableSortFilter, useTableSortFilter } from '../hooks/useTableSortFilter';
+import type { DiscoveredLeague, FollowedTeam, QualityProfile, Team } from '../types';
 
-// Supported sports for team following
 const SPORT_FILTERS = [
   { id: 'all', name: 'All Sports', icon: '🌍' },
   { id: 'Soccer', name: 'Soccer', icon: '⚽' },
@@ -24,23 +30,48 @@ const SPORT_FILTERS = [
   { id: 'Ice Hockey', name: 'Ice Hockey', icon: '🏒' },
 ];
 
-// Sport icons for display
-const SPORT_ICONS: Record<string, string> = {
-  'Soccer': '⚽',
-  'Football': '⚽',
-  'Basketball': '🏀',
-  'Ice Hockey': '🏒',
-  'Hockey': '🏒',
-};
-
-// Monitor type options
 const MONITOR_OPTIONS = [
   { value: 'Future', label: 'Future Events', description: 'Only monitor upcoming events' },
   { value: 'All', label: 'All Events', description: 'Monitor past and future events' },
   { value: 'None', label: 'None', description: 'Do not monitor events automatically' },
 ];
 
-// Helper to get sport icon
+const PAGE_PADDING = 'p-4 md:p-8';
+const TABLE_ROW_HOVER = 'text-sm transition-colors hover:bg-gray-800/50';
+const BADGE_RED = 'whitespace-nowrap rounded bg-red-900/30 px-1.5 py-0.5 text-xs text-red-400';
+const BADGE_GREEN = 'whitespace-nowrap rounded bg-green-900/30 px-1.5 py-0.5 text-xs text-green-400';
+const SCROLLABLE_LIST = 'max-h-60 overflow-y-auto';
+
+type TeamsColumnKey = 'badge' | 'name' | 'sport' | 'country' | 'status' | 'actions';
+
+const TEAM_COLUMN_DEFS: Array<{
+  key: TeamsColumnKey;
+  label: string;
+  alwaysVisible?: boolean;
+}> = [
+  { key: 'badge', label: 'Badge' },
+  { key: 'name', label: 'Team', alwaysVisible: true },
+  { key: 'sport', label: 'Sport' },
+  { key: 'country', label: 'Country' },
+  { key: 'status', label: 'Status' },
+  { key: 'actions', label: 'Actions', alwaysVisible: true },
+];
+
+interface TeamApiResponse {
+  Id?: number;
+  id?: number;
+  idTeam?: string;
+  strTeam?: string;
+  strTeamShort?: string;
+  strAlternate?: string;
+  strSport?: string;
+  strCountry?: string;
+  strTeamBadge?: string;
+  intFormedYear?: string;
+  Added?: string;
+  added?: string;
+}
+
 const getSportIcon = (sport: string): string => {
   const sportLower = sport.toLowerCase();
   if (sportLower.includes('soccer') || sportLower.includes('football')) return '⚽';
@@ -51,32 +82,56 @@ const getSportIcon = (sport: string): string => {
 
 export default function TeamsPage() {
   const queryClient = useQueryClient();
+  const compactView = useCompactView();
+  const isWideScreen = useIsWideScreen();
+  const {
+    sortCol,
+    sortDir,
+    colFilters,
+    activeFilterCol,
+    handleColSort,
+    onFilterChange,
+    onFilterToggle,
+  } = useTableSortFilter('name');
+  const { isVisible, toggleCol } = useColumnVisibility<TeamsColumnKey>(
+    'teams-col-visibility',
+    { badge: true, name: true, sport: true, country: true, status: true, actions: true },
+    ['name', 'actions']
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedSport, setSelectedSport] = useState('all');
   const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
   const [discoveredLeagues, setDiscoveredLeagues] = useState<DiscoveredLeague[]>([]);
   const [isDiscovering, setIsDiscovering] = useState(false);
   const [selectedLeagueIds, setSelectedLeagueIds] = useState<Set<string>>(new Set());
-
-  // League add settings
   const [monitorType, setMonitorType] = useState('Future');
   const [qualityProfileId, setQualityProfileId] = useState<number>(1);
   const [searchOnAdd, setSearchOnAdd] = useState(false);
   const [searchForUpgrades, setSearchForUpgrades] = useState(false);
   const [isAddingLeagues, setIsAddingLeagues] = useState(false);
 
-  // Fetch all teams for supported sports
   const { data: allTeams = [], isLoading: isLoadingTeams } = useQuery({
     queryKey: ['all-teams'],
     queryFn: async () => {
-      const response = await apiClient.get<Team[]>('/teams/all');
-      return response.data || [];
+      const response = await apiClient.get<TeamApiResponse[]>('/teams/all');
+
+      return (response.data || []).map((team): Team => ({
+        id: team.Id ?? team.id ?? 0,
+        externalId: team.idTeam,
+        name: team.strTeam ?? '',
+        shortName: team.strTeamShort,
+        alternateName: team.strAlternate,
+        sport: team.strSport ?? '',
+        country: team.strCountry,
+        badgeUrl: team.strTeamBadge,
+        formedYear: team.intFormedYear ? Number.parseInt(team.intFormedYear, 10) : undefined,
+        added: team.Added ?? team.added ?? new Date().toISOString(),
+      }));
     },
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
-  // Fetch followed teams to check which ones are already followed
   const { data: followedTeams = [] } = useQuery({
     queryKey: ['followed-teams'],
     queryFn: async () => {
@@ -85,7 +140,6 @@ export default function TeamsPage() {
     },
   });
 
-  // Fetch quality profiles for the dropdown
   const { data: qualityProfiles } = useQuery({
     queryKey: ['quality-profiles'],
     queryFn: async () => {
@@ -94,30 +148,28 @@ export default function TeamsPage() {
     },
   });
 
-  // Create a set of followed team external IDs for quick lookup
   const followedTeamIds = useMemo(() => {
     const ids = new Set<string>();
-    followedTeams.forEach(ft => {
-      if (ft.externalId) ids.add(ft.externalId);
+    followedTeams.forEach((team) => {
+      if (team.externalId) {
+        ids.add(team.externalId);
+      }
     });
     return ids;
   }, [followedTeams]);
 
-  // Filter teams based on selected sport and search query
   const filteredTeams = useMemo(() => {
     let filtered = allTeams;
 
-    // Filter by sport
     if (selectedSport !== 'all') {
-      filtered = filtered.filter(team =>
+      filtered = filtered.filter((team) =>
         team.sport?.toLowerCase().includes(selectedSport.toLowerCase())
       );
     }
 
-    // Filter by search query
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(team =>
+      filtered = filtered.filter((team) =>
         team.name?.toLowerCase().includes(query) ||
         team.shortName?.toLowerCase().includes(query) ||
         team.alternateName?.toLowerCase().includes(query) ||
@@ -125,28 +177,28 @@ export default function TeamsPage() {
       );
     }
 
-    return filtered;
-  }, [allTeams, selectedSport, searchQuery]);
+    return filtered
+      .filter((team) => {
+        const name = team.name ?? '';
+        return !name.startsWith('_') && !name.endsWith('_');
+      })
+      .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+  }, [allTeams, searchQuery, selectedSport]);
 
-  // Follow team mutation
   const followTeamMutation = useMutation({
-    mutationFn: async (team: Team) => {
-      return apiClient.post<FollowedTeam>('/followed-teams', {
-        externalId: team.externalId,
-        name: team.name,
-        sport: team.sport,
-        badgeUrl: team.badgeUrl,
-      });
-    },
+    mutationFn: async (team: Team) => apiClient.post<FollowedTeam>('/followed-teams', {
+      externalId: team.externalId,
+      name: team.name,
+      sport: team.sport,
+      badgeUrl: team.badgeUrl,
+    }),
     onSuccess: async (response, team) => {
-      // Invalidate and wait for refetch before discovering leagues
       await queryClient.invalidateQueries({ queryKey: ['followed-teams'] });
       toast.success(`Now following ${team.name}`);
-      // Expand the team card to show discovered leagues
+
       if (team.externalId && response.data?.id) {
         setExpandedTeamId(team.externalId);
-        // Use the returned followed team ID directly to avoid race condition
-        discoverLeaguesById(response.data.id, team.externalId);
+        await discoverLeaguesById(response.data.id);
       }
     },
     onError: (error: Error) => {
@@ -154,24 +206,21 @@ export default function TeamsPage() {
     },
   });
 
-  // Unfollow team mutation
   const unfollowTeamMutation = useMutation({
-    mutationFn: async (teamId: number) => {
-      return apiClient.delete(`/followed-teams/${teamId}`);
-    },
+    mutationFn: async (teamId: number) => apiClient.delete(`/followed-teams/${teamId}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['followed-teams'] });
       toast.success('Team unfollowed');
       setExpandedTeamId(null);
       setDiscoveredLeagues([]);
+      setSelectedLeagueIds(new Set());
     },
     onError: (error: Error) => {
       toast.error('Failed to unfollow team', { description: error.message });
     },
   });
 
-  // Discover leagues for a team by followed team ID (avoids race condition)
-  const discoverLeaguesById = async (followedTeamId: number, teamExternalId: string) => {
+  const discoverLeaguesById = async (followedTeamId: number) => {
     setIsDiscovering(true);
     setDiscoveredLeagues([]);
     setSelectedLeagueIds(new Set());
@@ -183,15 +232,9 @@ export default function TeamsPage() {
         leagues: DiscoveredLeague[];
       }>(`/followed-teams/${followedTeamId}/leagues`);
 
-      setDiscoveredLeagues(response.data.leagues || []);
-
-      // Auto-select leagues that aren't already added
-      const notAddedIds = new Set(
-        (response.data.leagues || [])
-          .filter(l => !l.isAdded)
-          .map(l => l.externalId)
-      );
-      setSelectedLeagueIds(notAddedIds);
+      const leagues = response.data.leagues || [];
+      setDiscoveredLeagues(leagues);
+      setSelectedLeagueIds(new Set(leagues.filter((league) => !league.isAdded).map((league) => league.externalId)));
     } catch {
       toast.error('Failed to discover leagues');
     } finally {
@@ -199,41 +242,41 @@ export default function TeamsPage() {
     }
   };
 
-  // Discover leagues for a team (looks up followed team by external ID)
   const discoverLeagues = async (teamExternalId: string) => {
-    const followedTeam = followedTeams.find(ft => ft.externalId === teamExternalId);
+    const followedTeam = followedTeams.find((team) => team.externalId === teamExternalId);
     if (!followedTeam) {
       toast.error('Team not found in followed teams');
       return;
     }
-    await discoverLeaguesById(followedTeam.id, teamExternalId);
+
+    await discoverLeaguesById(followedTeam.id);
   };
 
-  // Toggle team expansion
   const toggleTeamExpansion = (team: Team) => {
-    if (!team.externalId) return;
+    if (!team.externalId) {
+      return;
+    }
 
     if (expandedTeamId === team.externalId) {
       setExpandedTeamId(null);
       setDiscoveredLeagues([]);
       setSelectedLeagueIds(new Set());
-    } else {
-      const isFollowed = followedTeamIds.has(team.externalId);
-      if (isFollowed) {
-        setExpandedTeamId(team.externalId);
-        discoverLeagues(team.externalId);
-      }
+      return;
+    }
+
+    if (followedTeamIds.has(team.externalId)) {
+      setExpandedTeamId(team.externalId);
+      void discoverLeagues(team.externalId);
     }
   };
 
-  // Add selected leagues
   const handleAddLeagues = async (teamExternalId: string) => {
     if (selectedLeagueIds.size === 0) {
       toast.error('No leagues selected');
       return;
     }
 
-    const followedTeam = followedTeams.find(ft => ft.externalId === teamExternalId);
+    const followedTeam = followedTeams.find((team) => team.externalId === teamExternalId);
     if (!followedTeam) {
       toast.error('Team not found');
       return;
@@ -253,23 +296,22 @@ export default function TeamsPage() {
 
       if (added?.length > 0) {
         toast.success(`Added ${added.length} league(s)`, {
-          description: added.map((l: { name: string }) => l.name).join(', '),
+          description: added.map((league: { name: string }) => league.name).join(', '),
         });
       }
       if (skipped?.length > 0) {
         toast.info(`Skipped ${skipped.length} league(s)`, {
-          description: skipped.map((l: { name: string; reason: string }) => `${l.name}: ${l.reason}`).join(', '),
+          description: skipped.map((league: { name: string; reason: string }) => `${league.name}: ${league.reason}`).join(', '),
         });
       }
       if (errors?.length > 0) {
         toast.error(`Failed to add ${errors.length} league(s)`, {
-          description: errors.map((l: { reason: string }) => l.reason).join(', '),
+          description: errors.map((league: { reason: string }) => league.reason).join(', '),
         });
       }
 
-      // Refresh the discovered leagues to update isAdded status
-      discoverLeagues(teamExternalId);
-      queryClient.invalidateQueries({ queryKey: ['leagues'] });
+      await discoverLeagues(teamExternalId);
+      void queryClient.invalidateQueries({ queryKey: ['leagues'] });
     } catch {
       toast.error('Failed to add leagues');
     } finally {
@@ -277,10 +319,9 @@ export default function TeamsPage() {
     }
   };
 
-  // Toggle league selection
   const toggleLeagueSelection = (leagueId: string) => {
-    setSelectedLeagueIds(prev => {
-      const next = new Set(prev);
+    setSelectedLeagueIds((previous) => {
+      const next = new Set(previous);
       if (next.has(leagueId)) {
         next.delete(leagueId);
       } else {
@@ -290,33 +331,540 @@ export default function TeamsPage() {
     });
   };
 
-  // Select/deselect all leagues
   const toggleSelectAll = () => {
-    const notAddedLeagues = discoveredLeagues.filter(l => !l.isAdded);
+    const notAddedLeagues = discoveredLeagues.filter((league) => !league.isAdded);
     if (selectedLeagueIds.size === notAddedLeagues.length) {
       setSelectedLeagueIds(new Set());
-    } else {
-      setSelectedLeagueIds(new Set(notAddedLeagues.map(l => l.externalId)));
+      return;
     }
+
+    setSelectedLeagueIds(new Set(notAddedLeagues.map((league) => league.externalId)));
   };
 
-  // Get followed team by external ID
-  const getFollowedTeam = (externalId: string) => {
-    return followedTeams.find(ft => ft.externalId === externalId);
+  const getFollowedTeam = (externalId: string) =>
+    followedTeams.find((team) => team.externalId === externalId);
+
+  const expandedTeam = expandedTeamId
+    ? filteredTeams.find((team) => team.externalId === expandedTeamId)
+    : null;
+
+  const renderExpandedLeagues = (teamName: string, teamExternalId: string) => (
+    <div className="border-t border-gray-800 p-4 bg-gray-950/50">
+      {isDiscovering ? (
+        <div className="text-center py-8 text-gray-400">
+          <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto mb-2" />
+          Discovering leagues...
+        </div>
+      ) : discoveredLeagues.length === 0 ? (
+        <div className="text-center py-8 text-gray-400">
+          No leagues found for {teamName}
+        </div>
+      ) : (
+        <>
+          <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-4 mb-4">
+            <h4 className="font-medium text-white mb-3">League Settings (applied to all selected)</h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Monitor Events</label>
+                <select
+                  value={monitorType}
+                  onChange={(event) => setMonitorType(event.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
+                >
+                  {MONITOR_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Quality Profile</label>
+                <select
+                  value={qualityProfileId}
+                  onChange={(event) => setQualityProfileId(Number(event.target.value))}
+                  className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
+                >
+                  {qualityProfiles?.map((profile) => (
+                    <option key={profile.id} value={profile.id}>
+                      {profile.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="searchOnAdd"
+                  checked={searchOnAdd}
+                  onChange={(event) => setSearchOnAdd(event.target.checked)}
+                  className="w-4 h-4 rounded border-gray-600 text-red-600 focus:ring-red-500 bg-gray-800"
+                />
+                <label htmlFor="searchOnAdd" className="text-sm text-gray-300">
+                  Search for missing events
+                </label>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="searchForUpgrades"
+                  checked={searchForUpgrades}
+                  onChange={(event) => setSearchForUpgrades(event.target.checked)}
+                  className="w-4 h-4 rounded border-gray-600 text-red-600 focus:ring-red-500 bg-gray-800"
+                />
+                <label htmlFor="searchForUpgrades" className="text-sm text-gray-300">
+                  Search for quality upgrades
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={toggleSelectAll}
+                className="text-sm text-blue-400 hover:text-blue-300"
+              >
+                {selectedLeagueIds.size === discoveredLeagues.filter((league) => !league.isAdded).length
+                  ? 'Deselect All'
+                  : 'Select All'}
+              </button>
+              <span className="text-sm text-gray-400">
+                {selectedLeagueIds.size} league(s) selected
+              </span>
+            </div>
+
+            <button
+              onClick={() => handleAddLeagues(teamExternalId)}
+              disabled={selectedLeagueIds.size === 0 || isAddingLeagues}
+              className="px-4 py-2 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+            >
+              {isAddingLeagues ? (
+                <ArrowPathIcon className="w-4 h-4 animate-spin" />
+              ) : (
+                <PlusIcon className="w-4 h-4" />
+              )}
+              Add Selected Leagues ({selectedLeagueIds.size})
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {discoveredLeagues.map((league) => (
+              <div
+                key={league.externalId}
+                onClick={() => !league.isAdded && toggleLeagueSelection(league.externalId)}
+                className={`p-3 rounded-lg border transition-colors cursor-pointer ${
+                  league.isAdded
+                    ? 'bg-green-900/20 border-green-800/50 cursor-not-allowed'
+                    : selectedLeagueIds.has(league.externalId)
+                      ? 'bg-blue-900/30 border-blue-600'
+                      : 'bg-gray-900/50 border-gray-700 hover:border-gray-600'
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <div className={`w-5 h-5 rounded border flex items-center justify-center ${
+                    league.isAdded
+                      ? 'bg-green-600 border-green-600'
+                      : selectedLeagueIds.has(league.externalId)
+                        ? 'bg-blue-600 border-blue-600'
+                        : 'border-gray-600'
+                  }`}>
+                    {(league.isAdded || selectedLeagueIds.has(league.externalId)) && (
+                      <CheckIcon className="w-3 h-3 text-white" />
+                    )}
+                  </div>
+
+                  {league.badgeUrl ? (
+                    <img
+                      src={league.badgeUrl}
+                      alt={league.name}
+                      className="w-8 h-8 object-contain rounded"
+                    />
+                  ) : (
+                    <div className="w-8 h-8 bg-gray-800 rounded flex items-center justify-center text-lg">
+                      {getSportIcon(league.sport)}
+                    </div>
+                  )}
+
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-white truncate">{league.name}</p>
+                    <p className="text-xs text-gray-400">
+                      {league.country || league.sport} • {league.eventCount} events
+                    </p>
+                  </div>
+
+                  {league.isAdded && (
+                    <span className="px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded">
+                      Already Added
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+
+  const renderCompactTable = () => {
+    const tableData = applyTableSortFilter(
+      filteredTeams,
+      colFilters,
+      sortCol,
+      sortDir,
+      (col, team) => {
+        switch (col) {
+          case 'name':
+            return String(team.name || '');
+          case 'sport':
+            return String(team.sport || '');
+          case 'country':
+            return String(team.country || '');
+          default:
+            return '';
+        }
+      }
+    );
+
+    const leftTeams = tableData.filter((_, index) => index % 2 === 0);
+    const rightTeams = tableData.filter((_, index) => index % 2 === 1);
+
+    const visibleColumnCount = TEAM_COLUMN_DEFS.filter((column) => isVisible(column.key)).length;
+
+    const renderTable = (teams: Team[], showPicker = false) => (
+      <CompactTableFrame
+        controls={
+          showPicker ? (
+            <ColumnPicker
+              columns={TEAM_COLUMN_DEFS}
+              isVisible={(column) => isVisible(column as TeamsColumnKey)}
+              onToggle={(column) => toggleCol(column as TeamsColumnKey)}
+            />
+          ) : undefined
+        }
+        className="rounded-lg border border-red-900/30 bg-gradient-to-br from-gray-900 to-black"
+      >
+        <thead>
+          <tr className="sticky top-0 border-b border-gray-700 bg-gray-950 text-left text-xs uppercase text-gray-400">
+            {isVisible('badge') && <th className="w-12 px-2 py-1.5">Badge</th>}
+            <SortableFilterableHeader
+              col="name"
+              label="Team"
+              sortCol={sortCol}
+              sortDir={sortDir}
+              onSort={handleColSort}
+              colFilters={colFilters}
+              activeFilterCol={activeFilterCol}
+              onFilterChange={onFilterChange}
+              onFilterToggle={onFilterToggle}
+            />
+            {isVisible('sport') && (
+              <SortableFilterableHeader
+                col="sport"
+                label="Sport"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={handleColSort}
+                colFilters={colFilters}
+                activeFilterCol={activeFilterCol}
+                onFilterChange={onFilterChange}
+                onFilterToggle={onFilterToggle}
+                className="px-2 py-1.5"
+              />
+            )}
+            {isVisible('country') && (
+              <SortableFilterableHeader
+                col="country"
+                label="Country"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={handleColSort}
+                colFilters={colFilters}
+                activeFilterCol={activeFilterCol}
+                onFilterChange={onFilterChange}
+                onFilterToggle={onFilterToggle}
+                className="px-2 py-1.5"
+              />
+            )}
+            {isVisible('status') && <th className="px-2 py-1.5">Status</th>}
+            <th className="px-2 py-1.5 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-700">
+          {teams.map((team) => {
+            const isFollowed = team.externalId ? followedTeamIds.has(team.externalId) : false;
+            const followedTeam = team.externalId ? getFollowedTeam(team.externalId) : null;
+
+            return (
+              <tr key={team.externalId || team.id} className={TABLE_ROW_HOVER}>
+                {isVisible('badge') && (
+                  <td className="px-2 py-2">
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded bg-black/50">
+                      {team.badgeUrl ? (
+                        <img
+                          src={team.badgeUrl}
+                          alt={team.name}
+                          className="max-h-full max-w-full object-contain"
+                        />
+                      ) : (
+                        <span className="text-lg opacity-50">{getSportIcon(team.sport || '')}</span>
+                      )}
+                    </div>
+                  </td>
+                )}
+                <td className="px-3 py-2 font-medium text-white">
+                  <div>
+                    <div className="text-white">{team.name}</div>
+                    {team.alternateName && (
+                      <div className="text-xs text-gray-400">{team.alternateName}</div>
+                    )}
+                  </div>
+                </td>
+                {isVisible('sport') && (
+                  <td className="px-2 py-2">
+                    <span className={BADGE_RED}>{team.sport || 'Unknown'}</span>
+                  </td>
+                )}
+                {isVisible('country') && (
+                  <td className="px-2 py-2 text-sm text-gray-400">
+                    {team.country ? (
+                      <span className="flex items-center gap-1">
+                        <GlobeAltIcon className="h-3 w-3 flex-shrink-0" />
+                        {team.country}
+                      </span>
+                    ) : (
+                      <span className="text-gray-600">-</span>
+                    )}
+                  </td>
+                )}
+                {isVisible('status') && (
+                  <td className="px-2 py-2 text-sm">
+                    {isFollowed ? (
+                      <span className={BADGE_GREEN}>Following</span>
+                    ) : (
+                      <span className="text-gray-600">-</span>
+                    )}
+                  </td>
+                )}
+                <td className="px-2 py-2 text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    {isFollowed ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => toggleTeamExpansion(team)}
+                          className="rounded p-1.5 text-green-400 transition-colors hover:bg-green-900/30 hover:text-green-300"
+                          title={expandedTeamId === team.externalId ? 'Collapse' : 'Expand'}
+                        >
+                          {expandedTeamId === team.externalId ? (
+                            <ChevronUpIcon className="h-4 w-4" />
+                          ) : (
+                            <ChevronDownIcon className="h-4 w-4" />
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (followedTeam && confirm(`Unfollow ${team.name}?`)) {
+                              unfollowTeamMutation.mutate(followedTeam.id);
+                            }
+                          }}
+                          className="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-900/30 hover:text-red-400"
+                          title="Unfollow"
+                        >
+                          <TrashIcon className="h-4 w-4" />
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => followTeamMutation.mutate(team)}
+                        disabled={followTeamMutation.isPending}
+                        className="rounded p-1.5 text-red-400 transition-colors hover:bg-red-900/30 hover:text-red-300 disabled:opacity-50"
+                        title="Follow"
+                      >
+                        {followTeamMutation.isPending ? (
+                          <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <UserGroupIcon className="h-4 w-4" />
+                        )}
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+          {teams.length === 0 && (
+            <tr>
+              <td colSpan={visibleColumnCount} className="px-3 py-8 text-center text-gray-400">
+                No teams found
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </CompactTableFrame>
+    );
+
+    return (
+      <>
+        {tableData.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-gray-400">
+              {searchQuery || selectedSport !== 'all' ? 'No teams found' : 'No teams available'}
+            </p>
+          </div>
+        ) : isWideScreen ? (
+          <div className="grid grid-cols-2 gap-4">
+            <div>{renderTable(leftTeams, true)}</div>
+            <div>{renderTable(rightTeams, true)}</div>
+          </div>
+        ) : (
+          renderTable(tableData, true)
+        )}
+
+        {expandedTeam?.externalId && (
+          <div className="mt-4 rounded-lg border border-gray-800 bg-gray-950/50 p-4">
+            <h4 className="mb-3 font-medium text-white">{expandedTeam.name} - League Settings</h4>
+
+            {isDiscovering ? (
+              <div className="py-8 text-center text-gray-400">
+                <ArrowPathIcon className="mx-auto mb-2 h-8 w-8 animate-spin" />
+                Discovering leagues...
+              </div>
+            ) : discoveredLeagues.length === 0 ? (
+              <div className="py-8 text-center text-gray-400">
+                No leagues found for this team
+              </div>
+            ) : (
+              <>
+                <div className="mb-4 rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+                  <h5 className="mb-3 font-medium text-white">League Settings</h5>
+                  <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                    <div>
+                      <label className="mb-1 block text-sm text-gray-400">Monitor Events</label>
+                      <select
+                        value={monitorType}
+                        onChange={(event) => setMonitorType(event.target.value)}
+                        className="w-full rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white"
+                      >
+                        {MONITOR_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-sm text-gray-400">Quality Profile</label>
+                      <select
+                        value={qualityProfileId}
+                        onChange={(event) => setQualityProfileId(Number(event.target.value))}
+                        className="w-full rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white"
+                      >
+                        {qualityProfiles?.map((profile) => (
+                          <option key={profile.id} value={profile.id}>
+                            {profile.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="flex items-end">
+                      <label className="flex cursor-pointer items-center space-x-2">
+                        <input
+                          type="checkbox"
+                          checked={searchOnAdd}
+                          onChange={(event) => setSearchOnAdd(event.target.checked)}
+                          className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500"
+                        />
+                        <span className="text-sm text-gray-300">Search for missing</span>
+                      </label>
+                    </div>
+                    <div className="flex items-end">
+                      <label className="flex cursor-pointer items-center space-x-2">
+                        <input
+                          type="checkbox"
+                          checked={searchForUpgrades}
+                          onChange={(event) => setSearchForUpgrades(event.target.checked)}
+                          className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500"
+                        />
+                        <span className="text-sm text-gray-300">Search for upgrades</span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mb-3 flex items-center justify-between gap-4">
+                  <button
+                    type="button"
+                    onClick={toggleSelectAll}
+                    className="text-sm text-blue-400 hover:text-blue-300"
+                  >
+                    {selectedLeagueIds.size === discoveredLeagues.filter((league) => !league.isAdded).length
+                      ? 'Deselect All'
+                      : 'Select All'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (expandedTeam.externalId) {
+                        void handleAddLeagues(expandedTeam.externalId);
+                      }
+                    }}
+                    disabled={selectedLeagueIds.size === 0 || isAddingLeagues}
+                    className="flex items-center gap-2 rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isAddingLeagues ? (
+                      <ArrowPathIcon className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <PlusIcon className="h-4 w-4" />
+                    )}
+                    Add Selected ({selectedLeagueIds.size})
+                  </button>
+                </div>
+
+                <div className={`space-y-1 ${SCROLLABLE_LIST}`}>
+                  {discoveredLeagues.map((league) => (
+                    <label
+                      key={league.externalId}
+                      className="flex cursor-pointer items-center space-x-2 rounded p-2 text-sm hover:bg-gray-800/50"
+                    >
+                      {!league.isAdded && (
+                        <input
+                          type="checkbox"
+                          checked={selectedLeagueIds.has(league.externalId)}
+                          onChange={() => toggleLeagueSelection(league.externalId)}
+                          className="h-4 w-4 cursor-pointer rounded border-gray-600 bg-gray-800 text-red-600 focus:ring-red-500"
+                        />
+                      )}
+                      {league.isAdded && (
+                        <CheckIcon className="h-4 w-4 flex-shrink-0 text-green-400" />
+                      )}
+                      <span className="flex-1 text-white">{league.name}</span>
+                      {league.isAdded && <span className="text-xs text-green-400">Added</span>}
+                    </label>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </>
+    );
   };
 
   return (
-    <div className="p-8">
-      <div className="max-w-7xl mx-auto">
-        {/* Header */}
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-white mb-2">Add Team</h1>
-          <p className="text-gray-400">
-            Follow teams across multiple leagues. When you follow a team, you can add all their leagues at once.
-          </p>
-        </div>
+    <div className={PAGE_PADDING}>
+      <div className="mx-auto max-w-7xl">
+        <PageHeader
+          title="Add Team"
+          subtitle="Follow teams across multiple leagues. When you follow a team, you can add all their leagues at once."
+        />
 
-        {/* Supported Sports Notice */}
         <div className="bg-gradient-to-r from-blue-900/30 to-purple-900/30 border border-blue-700/30 rounded-lg p-4 mb-6">
           <p className="text-sm text-gray-300">
             <span className="font-semibold text-white">Follow Team</span> is currently available for{' '}
@@ -344,15 +892,13 @@ export default function TeamsPage() {
           </p>
         </div>
 
-        {/* Search Controls */}
         <div className="bg-gradient-to-br from-gray-900 to-black border border-red-900/30 rounded-lg p-6 mb-6">
-          {/* Sport Filter */}
           <div className="mb-4">
             <label className="block text-sm font-medium text-gray-300 mb-2">
               Filter by Sport
             </label>
             <div className="flex flex-wrap gap-2">
-              {SPORT_FILTERS.map(sport => (
+              {SPORT_FILTERS.map((sport) => (
                 <button
                   key={sport.id}
                   onClick={() => setSelectedSport(sport.id)}
@@ -369,29 +915,27 @@ export default function TeamsPage() {
             </div>
           </div>
 
-          {/* Search Input */}
           <div className="relative">
             <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" />
             <input
               type="text"
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Filter teams (e.g., Real Madrid, Lakers, Bruins)..."
               className="w-full pl-10 pr-4 py-3 bg-black border border-red-900/30 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-red-600 focus:ring-1 focus:ring-red-600"
             />
           </div>
 
           <p className="text-sm text-gray-500 mt-3">
-            💡 Showing {isLoadingTeams ? '...' : filteredTeams.length} of {allTeams.length} teams
+            Showing {isLoadingTeams ? '...' : filteredTeams.length} of {allTeams.length} teams
             {searchQuery && ` matching "${searchQuery}"`}
-            {selectedSport !== 'all' && ` in ${SPORT_FILTERS.find(s => s.id === selectedSport)?.name}`}
+            {selectedSport !== 'all' && ` in ${SPORT_FILTERS.find((sport) => sport.id === selectedSport)?.name}`}
           </p>
         </div>
 
-        {/* Loading State */}
         {isLoadingTeams && (
           <div className="text-center py-16">
-            <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-red-600 mx-auto mb-4"></div>
+            <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-red-600 mx-auto mb-4" />
             <h3 className="text-xl font-semibold text-gray-400 mb-2">
               Loading Teams...
             </h3>
@@ -401,305 +945,134 @@ export default function TeamsPage() {
           </div>
         )}
 
-        {/* Teams Grid */}
-        {!isLoadingTeams && filteredTeams.length > 0 && (
+        {!isLoadingTeams && (
           <div>
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-semibold text-white">
-                {selectedSport === 'all' ? 'All Teams' : `${SPORT_FILTERS.find(s => s.id === selectedSport)?.name} Teams`}
-                {' '}({filteredTeams.length})
+                {selectedSport === 'all' ? 'All Teams' : `${SPORT_FILTERS.find((sport) => sport.id === selectedSport)?.name} Teams`}
+                {filteredTeams.length > 0 && ` (${filteredTeams.length})`}
               </h2>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {filteredTeams.map(team => {
-                const isFollowed = team.externalId ? followedTeamIds.has(team.externalId) : false;
-                const isExpanded = expandedTeamId === team.externalId;
-                const followedTeam = team.externalId ? getFollowedTeam(team.externalId) : null;
+            {compactView ? (
+              renderCompactTable()
+            ) : filteredTeams.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {filteredTeams.map((team) => {
+                  const isFollowed = team.externalId ? followedTeamIds.has(team.externalId) : false;
+                  const isExpanded = expandedTeamId === team.externalId;
+                  const followedTeam = team.externalId ? getFollowedTeam(team.externalId) : null;
 
-                return (
-                  <div
-                    key={team.externalId || team.id}
-                    className={`bg-gradient-to-br from-gray-900 to-black border rounded-lg overflow-hidden transition-all ${
-                      isExpanded
-                        ? 'border-red-600 col-span-1 md:col-span-2 lg:col-span-3'
-                        : 'border-red-900/30 hover:border-red-700/50'
-                    }`}
-                  >
-                    {/* Team Card */}
-                    <div className="flex items-center p-4">
-                      {/* Team Badge */}
-                      <div className="h-16 w-16 bg-black/50 flex items-center justify-center rounded-lg mr-4 flex-shrink-0">
-                        {team.badgeUrl ? (
-                          <img
-                            src={team.badgeUrl}
-                            alt={team.name}
-                            className="max-h-full max-w-full object-contain"
-                          />
-                        ) : (
-                          <span className="text-3xl opacity-50">
-                            {getSportIcon(team.sport || '')}
-                          </span>
-                        )}
-                      </div>
-
-                      {/* Team Info */}
-                      <div className="flex-1 min-w-0">
-                        <h3 className="text-lg font-bold text-white truncate">
-                          {team.name}
-                        </h3>
-                        {team.alternateName && (
-                          <p className="text-sm text-gray-400 truncate">
-                            {team.alternateName}
-                          </p>
-                        )}
-                        <div className="flex items-center gap-2 mt-1">
-                          <span className="px-2 py-0.5 bg-red-600/20 text-red-400 text-xs rounded font-medium">
-                            {team.sport}
-                          </span>
-                          {team.country && (
-                            <span className="flex items-center gap-1 text-xs text-gray-400">
-                              <GlobeAltIcon className="w-3 h-3" />
-                              {team.country}
+                  return (
+                    <div
+                      key={team.externalId || team.id}
+                      className={`bg-gradient-to-br from-gray-900 to-black border rounded-lg overflow-hidden transition-all ${
+                        isExpanded
+                          ? 'border-red-600 col-span-1 md:col-span-2 lg:col-span-3'
+                          : 'border-red-900/30 hover:border-red-700/50'
+                      }`}
+                    >
+                      <div className="flex items-center p-4">
+                        <div className="h-16 w-16 bg-black/50 flex items-center justify-center rounded-lg mr-4 flex-shrink-0">
+                          {team.badgeUrl ? (
+                            <img
+                              src={team.badgeUrl}
+                              alt={team.name}
+                              className="max-h-full max-w-full object-contain"
+                            />
+                          ) : (
+                            <span className="text-3xl opacity-50">
+                              {getSportIcon(team.sport || '')}
                             </span>
+                          )}
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <h3 className="text-lg font-bold text-white truncate">
+                            {team.name}
+                          </h3>
+                          {team.alternateName && (
+                            <p className="text-sm text-gray-400 truncate">
+                              {team.alternateName}
+                            </p>
+                          )}
+                          <div className="flex items-center gap-2 mt-1">
+                            <span className="px-2 py-0.5 bg-red-600/20 text-red-400 text-xs rounded font-medium">
+                              {team.sport}
+                            </span>
+                            {team.country && (
+                              <span className="flex items-center gap-1 text-xs text-gray-400">
+                                <GlobeAltIcon className="w-3 h-3" />
+                                {team.country}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-2 ml-4">
+                          {isFollowed ? (
+                            <>
+                              <button
+                                onClick={() => toggleTeamExpansion(team)}
+                                className="px-4 py-2 rounded-lg font-medium bg-green-900/30 text-green-400 border border-green-700 hover:bg-green-900/50 transition-colors flex items-center gap-2"
+                              >
+                                <CheckCircleIcon className="w-5 h-5" />
+                                Following
+                                {isExpanded ? (
+                                  <ChevronUpIcon className="w-4 h-4" />
+                                ) : (
+                                  <ChevronDownIcon className="w-4 h-4" />
+                                )}
+                              </button>
+                              <button
+                                onClick={() => {
+                                  if (followedTeam && confirm(`Unfollow ${team.name}?`)) {
+                                    unfollowTeamMutation.mutate(followedTeam.id);
+                                  }
+                                }}
+                                className="p-2 text-gray-400 hover:text-red-400 transition-colors"
+                                title="Unfollow team"
+                              >
+                                <TrashIcon className="w-5 h-5" />
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              onClick={() => followTeamMutation.mutate(team)}
+                              disabled={followTeamMutation.isPending}
+                              className="px-4 py-2 rounded-lg font-medium bg-red-600 hover:bg-red-700 text-white transition-colors flex items-center gap-2 disabled:opacity-60"
+                            >
+                              {followTeamMutation.isPending ? (
+                                <ArrowPathIcon className="w-5 h-5 animate-spin" />
+                              ) : (
+                                <UserGroupIcon className="w-5 h-5" />
+                              )}
+                              Follow
+                            </button>
                           )}
                         </div>
                       </div>
 
-                      {/* Action Buttons */}
-                      <div className="flex items-center gap-2 ml-4">
-                        {isFollowed ? (
-                          <>
-                            <button
-                              onClick={() => toggleTeamExpansion(team)}
-                              className="px-4 py-2 rounded-lg font-medium bg-green-900/30 text-green-400 border border-green-700 hover:bg-green-900/50 transition-colors flex items-center gap-2"
-                            >
-                              <CheckCircleIcon className="w-5 h-5" />
-                              Following
-                              {isExpanded ? (
-                                <ChevronUpIcon className="w-4 h-4" />
-                              ) : (
-                                <ChevronDownIcon className="w-4 h-4" />
-                              )}
-                            </button>
-                            <button
-                              onClick={() => {
-                                if (followedTeam && confirm(`Unfollow ${team.name}?`)) {
-                                  unfollowTeamMutation.mutate(followedTeam.id);
-                                }
-                              }}
-                              className="p-2 text-gray-400 hover:text-red-400 transition-colors"
-                              title="Unfollow team"
-                            >
-                              <TrashIcon className="w-5 h-5" />
-                            </button>
-                          </>
-                        ) : (
-                          <button
-                            onClick={() => followTeamMutation.mutate(team)}
-                            disabled={followTeamMutation.isPending}
-                            className="px-4 py-2 rounded-lg font-medium bg-red-600 hover:bg-red-700 text-white transition-colors flex items-center gap-2"
-                          >
-                            {followTeamMutation.isPending ? (
-                              <ArrowPathIcon className="w-5 h-5 animate-spin" />
-                            ) : (
-                              <UserGroupIcon className="w-5 h-5" />
-                            )}
-                            Follow
-                          </button>
-                        )}
-                      </div>
+                      {isExpanded && team.externalId && renderExpandedLeagues(team.name, team.externalId)}
                     </div>
-
-                    {/* Expanded Leagues Section */}
-                    {isExpanded && (
-                      <div className="border-t border-gray-800 p-4 bg-gray-950/50">
-                        {isDiscovering ? (
-                          <div className="text-center py-8 text-gray-400">
-                            <ArrowPathIcon className="w-8 h-8 animate-spin mx-auto mb-2" />
-                            Discovering leagues...
-                          </div>
-                        ) : discoveredLeagues.length === 0 ? (
-                          <div className="text-center py-8 text-gray-400">
-                            No leagues found for this team
-                          </div>
-                        ) : (
-                          <>
-                            {/* League Settings */}
-                            <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-4 mb-4">
-                              <h4 className="font-medium text-white mb-3">League Settings (applied to all selected)</h4>
-                              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                                {/* Monitor Type */}
-                                <div>
-                                  <label className="block text-sm text-gray-400 mb-1">Monitor Events</label>
-                                  <select
-                                    value={monitorType}
-                                    onChange={(e) => setMonitorType(e.target.value)}
-                                    className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
-                                  >
-                                    {MONITOR_OPTIONS.map(opt => (
-                                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                                    ))}
-                                  </select>
-                                </div>
-
-                                {/* Quality Profile */}
-                                <div>
-                                  <label className="block text-sm text-gray-400 mb-1">Quality Profile</label>
-                                  <select
-                                    value={qualityProfileId}
-                                    onChange={(e) => setQualityProfileId(Number(e.target.value))}
-                                    className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
-                                  >
-                                    {qualityProfiles?.map(qp => (
-                                      <option key={qp.id} value={qp.id}>{qp.name}</option>
-                                    ))}
-                                  </select>
-                                </div>
-
-                                {/* Search on Add */}
-                                <div className="flex items-center gap-2">
-                                  <input
-                                    type="checkbox"
-                                    id="searchOnAdd"
-                                    checked={searchOnAdd}
-                                    onChange={(e) => setSearchOnAdd(e.target.checked)}
-                                    className="w-4 h-4 rounded border-gray-600 text-red-600 focus:ring-red-500 bg-gray-800"
-                                  />
-                                  <label htmlFor="searchOnAdd" className="text-sm text-gray-300">
-                                    Search for missing events
-                                  </label>
-                                </div>
-
-                                {/* Search for Upgrades */}
-                                <div className="flex items-center gap-2">
-                                  <input
-                                    type="checkbox"
-                                    id="searchForUpgrades"
-                                    checked={searchForUpgrades}
-                                    onChange={(e) => setSearchForUpgrades(e.target.checked)}
-                                    className="w-4 h-4 rounded border-gray-600 text-red-600 focus:ring-red-500 bg-gray-800"
-                                  />
-                                  <label htmlFor="searchForUpgrades" className="text-sm text-gray-300">
-                                    Search for quality upgrades
-                                  </label>
-                                </div>
-                              </div>
-                            </div>
-
-                            {/* League Selection */}
-                            <div className="flex items-center justify-between mb-3">
-                              <div className="flex items-center gap-4">
-                                <button
-                                  onClick={toggleSelectAll}
-                                  className="text-sm text-blue-400 hover:text-blue-300"
-                                >
-                                  {selectedLeagueIds.size === discoveredLeagues.filter(l => !l.isAdded).length
-                                    ? 'Deselect All'
-                                    : 'Select All'}
-                                </button>
-                                <span className="text-sm text-gray-400">
-                                  {selectedLeagueIds.size} league(s) selected
-                                </span>
-                              </div>
-                              <button
-                                onClick={() => team.externalId && handleAddLeagues(team.externalId)}
-                                disabled={selectedLeagueIds.size === 0 || isAddingLeagues}
-                                className="px-4 py-2 bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
-                              >
-                                {isAddingLeagues ? (
-                                  <ArrowPathIcon className="w-4 h-4 animate-spin" />
-                                ) : (
-                                  <PlusIcon className="w-4 h-4" />
-                                )}
-                                Add Selected Leagues ({selectedLeagueIds.size})
-                              </button>
-                            </div>
-
-                            {/* Leagues List */}
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                              {discoveredLeagues.map((league) => (
-                                <div
-                                  key={league.externalId}
-                                  onClick={() => !league.isAdded && toggleLeagueSelection(league.externalId)}
-                                  className={`p-3 rounded-lg border transition-colors cursor-pointer ${
-                                    league.isAdded
-                                      ? 'bg-green-900/20 border-green-800/50 cursor-not-allowed'
-                                      : selectedLeagueIds.has(league.externalId)
-                                      ? 'bg-blue-900/30 border-blue-600'
-                                      : 'bg-gray-900/50 border-gray-700 hover:border-gray-600'
-                                  }`}
-                                >
-                                  <div className="flex items-center gap-3">
-                                    {/* Checkbox */}
-                                    <div className={`w-5 h-5 rounded border flex items-center justify-center ${
-                                      league.isAdded
-                                        ? 'bg-green-600 border-green-600'
-                                        : selectedLeagueIds.has(league.externalId)
-                                        ? 'bg-blue-600 border-blue-600'
-                                        : 'border-gray-600'
-                                    }`}>
-                                      {(league.isAdded || selectedLeagueIds.has(league.externalId)) && (
-                                        <CheckIcon className="w-3 h-3 text-white" />
-                                      )}
-                                    </div>
-
-                                    {/* League Badge */}
-                                    {league.badgeUrl ? (
-                                      <img
-                                        src={league.badgeUrl}
-                                        alt={league.name}
-                                        className="w-8 h-8 object-contain rounded"
-                                      />
-                                    ) : (
-                                      <div className="w-8 h-8 bg-gray-800 rounded flex items-center justify-center text-lg">
-                                        {getSportIcon(league.sport)}
-                                      </div>
-                                    )}
-
-                                    {/* League Info */}
-                                    <div className="flex-1 min-w-0">
-                                      <p className="font-medium text-white truncate">{league.name}</p>
-                                      <p className="text-xs text-gray-400">
-                                        {league.country || league.sport} • {league.eventCount} events
-                                      </p>
-                                    </div>
-
-                                    {/* Status Badge */}
-                                    {league.isAdded && (
-                                      <span className="px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded">
-                                        Already Added
-                                      </span>
-                                    )}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* Empty State */}
-        {!isLoadingTeams && filteredTeams.length === 0 && (
-          <div className="text-center py-16">
-            <UserGroupIcon className="w-16 h-16 text-gray-600 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-gray-400 mb-2">
-              {searchQuery || selectedSport !== 'all'
-                ? 'No Teams Found'
-                : 'No Teams Available'}
-            </h3>
-            <p className="text-gray-500">
-              {searchQuery || selectedSport !== 'all'
-                ? 'Try adjusting your search or filter to see more results'
-                : 'No teams are available for the supported sports'}
-            </p>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="text-center py-16">
+                <UserGroupIcon className="w-16 h-16 text-gray-600 mx-auto mb-4" />
+                <h3 className="text-xl font-semibold text-gray-400 mb-2">
+                  {searchQuery || selectedSport !== 'all'
+                    ? 'No Teams Found'
+                    : 'No Teams Available'}
+                </h3>
+                <p className="text-gray-500">
+                  {searchQuery || selectedSport !== 'all'
+                    ? 'Try adjusting your search or filter to see more results'
+                    : 'No teams are available for the supported sports'}
+                </p>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/settings/UISettings.tsx
+++ b/frontend/src/pages/settings/UISettings.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { PaintBrushIcon, CalendarIcon, ClockIcon, EyeIcon, GlobeAltIcon } from '@heroicons/react/24/outline';
-import { apiGet, apiPost, apiPut, apiDelete } from '../../utils/api';
+import { useQueryClient } from '@tanstack/react-query';
+import { apiGet, apiPut } from '../../utils/api';
 import SettingsHeader from '../../components/SettingsHeader';
 import { useUnsavedChanges } from '../../hooks/useUnsavedChanges';
+import { UI_SETTINGS_QUERY_KEY } from '../../hooks/useUISettings';
 
 interface TimezoneInfo {
   id: string;
@@ -42,7 +44,8 @@ export default function UISettings({ showAdvanced = false }: UISettingsProps) {
   const [saving, setSaving] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const initialSettings = useRef<UISettingsData | null>(null);
-  const { blockNavigation } = useUnsavedChanges(hasUnsavedChanges);
+  useUnsavedChanges(hasUnsavedChanges);
+  const queryClient = useQueryClient();
   const [timezones, setTimezones] = useState<TimezoneInfo[]>([]);
   const [systemTimezone, setSystemTimezone] = useState<string>('');
   const [settings, setSettings] = useState<UISettingsData>({
@@ -136,6 +139,10 @@ export default function UISettings({ showAdvanced = false }: UISettingsProps) {
       if (saveResponse.ok) {
         initialSettings.current = settings;
         setHasUnsavedChanges(false);
+        queryClient.setQueryData(UI_SETTINGS_QUERY_KEY, {
+          timeZone: settings.timeZone,
+          eventViewMode: settings.eventViewMode,
+        });
       } else {
         console.error('Failed to save UI settings');
       }

--- a/src/Sportarr.csproj
+++ b/src/Sportarr.csproj
@@ -67,6 +67,16 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
+  <!-- Local agent worktrees may exist under src/Data/agents for experimentation.
+       Exclude them from the main app project; the shipped plugin payload comes
+       from the top-level ../agents directory below. -->
+  <ItemGroup>
+    <Compile Remove="Data/agents/**/*.cs" />
+    <Content Remove="Data/agents/**" />
+    <EmbeddedResource Remove="Data/agents/**" />
+    <None Remove="Data/agents/**" />
+  </ItemGroup>
+
   <!-- Include media server agents in build output -->
   <ItemGroup>
     <None Include="..\agents\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="agents" />


### PR DESCRIPTION
This PR introduces some shared components that I intend to apply to all of the screens through Soprtarr, but the PR would be way too big if I did them all together. So I've fixed a bug in the Add Teams page, and updated only that page to the new style. 

It introduces a standard table style, a column picker that will be standard on all pages that have the tables, sorting/filtering capabilities, a mechanism for rendering either compact or spacious views, and fixed the UI settings, as the compact mode wasn't actually consistently taking effect. 

Due to the number of teams rendered on this page, I also used a two column approach. 

Also a tiny change to the csproj file to help re-run builds easily. 

I've tested this a bunch, seems good to me, I think it's worth knowing that you're happy with the refactoring before I go and apply to all the other screens though.
