### PR TITLE
add additional queries for indexers

### DIFF
--- a/src/Services/EventQueryService.cs
+++ b/src/Services/EventQueryService.cs
@@ -146,6 +146,7 @@ public class EventQueryService
     /// - WWE RAW 2026-03-02 -> Primary: "WWE RAW 2026 03 02", Fallback: "WWE RAW 2026 03"
     /// - UFC 299 -> Primary: "UFC 299", Fallback: "UFC 2026"
     /// - NFL Dec 2025 -> Primary: "NFL 2025 12", Fallback: "NFL 2025"
+    /// - NBA Mar 2026 Miami Heat vs LAL -> Primary: "NBA 2026 03 Lakers", "NBA 2026 03 Heat", Fallback: "NBA 2026 03", "NBA 2026"
     /// </summary>
     /// <param name="evt">The event to build queries for</param>
     /// <param name="part">Optional - IGNORED. Parts are filtered locally from results.</param>
@@ -407,7 +408,9 @@ public class EventQueryService
 
     /// <summary>
     /// Build team sport queries (NFL, NBA, NHL, MLB, etc.).
-    /// Primary: league + year + month. Fallback: league + year.
+    /// When team names are available, emits team-specific queries first (most specific),
+    /// then falls back to league + year + month, and finally league + year only.
+    /// Up to 4 queries total; deduplicates if both teams share the same nickname.
     /// </summary>
     private void BuildTeamSportQueries(Event evt, string? leagueName, List<string> queries)
     {
@@ -421,11 +424,37 @@ public class EventQueryService
 
         var year = evt.EventDate.Year;
         var month = evt.EventDate.Month;
+        var monthStr = month.ToString("D2");
 
-        // Primary: "NFL 2025 12" (year + month)
-        queries.Add($"{leaguePrefix} {year} {month:D2}");
-        // Fallback: "NFL 2025" (year only)
+        // Resolve team names (prefer navigation property Name, fall back to string fields)
+        var homeTeamName = evt.HomeTeam?.Name ?? evt.HomeTeamName;
+        var awayTeamName = evt.AwayTeam?.Name ?? evt.AwayTeamName;
+
+        // Extract nickname (last word) for each team
+        var homeNickname = GetTeamNickname(homeTeamName);
+        var awayNickname = GetTeamNickname(awayTeamName);
+
+        // Team-specific queries (most specific first); deduplicate if both nicknames are identical
+        if (!string.IsNullOrEmpty(homeNickname))
+            queries.Add($"{leaguePrefix} {year} {monthStr} {homeNickname}");
+        if (!string.IsNullOrEmpty(awayNickname) && awayNickname != homeNickname)
+            queries.Add($"{leaguePrefix} {year} {monthStr} {awayNickname}");
+
+        // Existing queries as fallbacks
+        queries.Add($"{leaguePrefix} {year} {monthStr}");
         queries.Add($"{leaguePrefix} {year}");
+    }
+
+    /// <summary>
+    /// Extract the team nickname (last significant word) from a full team name.
+    /// e.g. "Los Angeles Lakers" -> "Lakers", "Miami Heat" -> "Heat"
+    /// Returns null if the name cannot be processed.
+    /// </summary>
+    private static string? GetTeamNickname(string? teamName)
+    {
+        if (string.IsNullOrWhiteSpace(teamName)) return null;
+        var parts = teamName.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length > 0 ? parts[^1] : null;
     }
 
 

--- a/tests/Sportarr.Api.Tests/Services/EventQueryServiceTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/EventQueryServiceTests.cs
@@ -1,0 +1,127 @@
+using Sportarr.Api.Services;
+using Sportarr.Api.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Tests for EventQueryService.BuildEventQueries, focused on team sport query generation.
+/// </summary>
+public class EventQueryServiceTests
+{
+    private readonly EventQueryService _service;
+
+    public EventQueryServiceTests()
+    {
+        var logger = new Mock<ILogger<EventQueryService>>();
+        _service = new EventQueryService(logger.Object);
+    }
+
+    private static Event MakeNbaEvent(
+        string? homeTeamName = null,
+        string? awayTeamName = null,
+        Team? homeTeam = null,
+        Team? awayTeam = null)
+    {
+        return new Event
+        {
+            Title = "NBA Test Event",
+            Sport = "Basketball",
+            EventDate = new DateTime(2026, 3, 19, 0, 0, 0, DateTimeKind.Utc),
+            League = new League { Name = "NBA", Sport = "Basketball" },
+            HomeTeamName = homeTeamName,
+            AwayTeamName = awayTeamName,
+            HomeTeam = homeTeam,
+            AwayTeam = awayTeam,
+        };
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_WithBothTeams_EmitsFourQueries()
+    {
+        var evt = MakeNbaEvent(homeTeamName: "Los Angeles Lakers", awayTeamName: "Miami Heat");
+
+        var queries = _service.BuildEventQueries(evt);
+
+        queries.Should().HaveCount(4);
+        queries[0].Should().Be("NBA 2026 03 Lakers");
+        queries[1].Should().Be("NBA 2026 03 Heat");
+        queries[2].Should().Be("NBA 2026 03");
+        queries[3].Should().Be("NBA 2026");
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_HomeTeamOnly_EmitsThreeQueries()
+    {
+        var evt = MakeNbaEvent(homeTeamName: "Golden State Warriors");
+
+        var queries = _service.BuildEventQueries(evt);
+
+        queries.Should().HaveCount(3);
+        queries[0].Should().Be("NBA 2026 03 Warriors");
+        queries[1].Should().Be("NBA 2026 03");
+        queries[2].Should().Be("NBA 2026");
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_NoTeams_EmitsTwoQueries()
+    {
+        var evt = MakeNbaEvent();
+
+        var queries = _service.BuildEventQueries(evt);
+
+        queries.Should().HaveCount(2);
+        queries[0].Should().Be("NBA 2026 03");
+        queries[1].Should().Be("NBA 2026");
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_NavigationTeamPreferredOverStringField()
+    {
+        var evt = MakeNbaEvent(
+            homeTeamName: "Old Name Lakers",
+            awayTeamName: "Old Name Heat",
+            homeTeam: new Team { Name = "Oklahoma City Thunder" },
+            awayTeam: new Team { Name = "Dallas Mavericks" });
+
+        var queries = _service.BuildEventQueries(evt);
+
+        queries.Should().Contain("NBA 2026 03 Thunder");
+        queries.Should().Contain("NBA 2026 03 Mavericks");
+        queries.Should().NotContain(q => q.Contains("Lakers") || q.Contains("Heat"));
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_SameNickname_Deduplicated()
+    {
+        // Both teams end in "United" (e.g. "Manchester United" vs "Leeds United")
+        var evt = new Event
+        {
+            Title = "MLS Test",
+            Sport = "Soccer",
+            EventDate = new DateTime(2026, 3, 19, 0, 0, 0, DateTimeKind.Utc),
+            League = new League { Name = "MLS", Sport = "Soccer" },
+            HomeTeamName = "Atlanta United",
+            AwayTeamName = "New England United",
+        };
+
+        var queries = _service.BuildEventQueries(evt);
+
+        // "United" appears only once in team queries
+        queries.Count(q => q.Contains("United")).Should().Be(1);
+        queries.Should().HaveCount(3); // home-nickname, date, year
+    }
+
+    [Fact]
+    public void BuildEventQueries_TeamSport_SingleWordTeamName_ExtractsCorrectly()
+    {
+        var evt = MakeNbaEvent(homeTeamName: "Heat", awayTeamName: "Jazz");
+
+        var queries = _service.BuildEventQueries(evt);
+
+        queries[0].Should().Be("NBA 2026 03 Heat");
+        queries[1].Should().Be("NBA 2026 03 Jazz");
+    }
+}


### PR DESCRIPTION
Hello ! 

After performing some research, I tried some queries in my jackett using the indexer 720pier. For NBA Sportarr seem to only use for 'NBA YEAR MONTH' but this returns nothing from the indexer while 'NBA YEAR MONTH TEAM_NAME' seem to return indeed all games for the months of a given team. 

Therefore, in this PR i propose to add another queries to retrieve more results.

Lemme know your thoughts :) 