### PR TITLE
Fix release profiles with tags being ignored during indexer searches

### DIFF
--- a/src/Services/IndexerSearchService.cs
+++ b/src/Services/IndexerSearchService.cs
@@ -325,7 +325,7 @@ public class IndexerSearchService : IIndexerSearchService
             // Apply release profile filtering (Required/Ignored keywords, Preferred score)
             if (releaseProfiles.Any())
             {
-                var profileEval = _releaseProfileService.EvaluateRelease(release, releaseProfiles);
+                var profileEval = _releaseProfileService.EvaluateRelease(release, releaseProfiles, leagueTags);
 
                 // Add rejections from release profiles
                 if (profileEval.IsRejected)


### PR DESCRIPTION
leagueTags was received by SearchAllIndexersAsync but never forwarded to ReleaseProfileService.EvaluateRelease. This caused TagHelper.TagsMatch to see an empty list, silently skipping any profile with tags configured. Affected both manual and automatic live searches.