### PR TITLE
Fix F1 BILLIE-style location releases not found; add MotoGP Gear Up pre-show detection

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9551,6 +9551,11 @@ app.MapPost("/api/event/{eventId:int}/search", async (
             usedCache = true;
             logger.LogInformation("[SEARCH] Using {Count} cached raw releases for '{Query}' - will re-match against event '{EventTitle}'",
                 allResults.Count, primaryQuery, evt.Title);
+
+            // Pre-populate seenGuids so supplementary queries below don't re-add cached releases
+            foreach (var r in allResults)
+                if (!string.IsNullOrEmpty(r.Guid))
+                    seenGuids.Add(r.Guid);
         }
     }
     else
@@ -9560,19 +9565,20 @@ app.MapPost("/api/event/{eventId:int}/search", async (
         logger.LogInformation("[SEARCH] Force refresh - invalidated cache for '{Query}'", primaryQuery);
     }
 
-    // If no cache hit, query indexers
-    if (!usedCache)
-    {
-        // OPTIMIZATION: Intelligent fallback search (matches AutomaticSearchService)
-        // Try primary query first, only fallback if insufficient results
-        int queriesAttempted = 0;
-        const int MinimumResults = 10; // Minimum results before stopping (manual search wants more options)
+    // Run all queries: live queries when no cache hit; supplementary queries always.
+    // Supplementary queries (Skip(1)) target alternative naming conventions (e.g. BILLIE-style
+    // F1 location releases) that the primary query may not reach. They must run even on cache hit.
+    var queriesToRun = usedCache ? queries.Skip(1).ToList() : queries.ToList();
 
-        foreach (var query in queries)
+    if (queriesToRun.Any())
+    {
+        int queriesAttempted = 0;
+
+        foreach (var query in queriesToRun)
         {
             queriesAttempted++;
             logger.LogInformation("[SEARCH] Trying query {Attempt}/{Total}: '{Query}'",
-                queriesAttempted, queries.Count, query);
+                queriesAttempted, queriesToRun.Count, query);
 
             // Pass enableMultiPartEpisodes to ensure proper part filtering
             // When disabled for fighting sports, this rejects releases with detected parts (Main Card, Prelims, etc.)
@@ -9588,23 +9594,15 @@ app.MapPost("/api/event/{eventId:int}/search", async (
                 }
             }
 
-            // Success criteria: Found enough results for user to choose from
-            if (allResults.Count >= MinimumResults)
+            // Log progress
+            if (results.Count > 0)
             {
-                logger.LogInformation("[SEARCH] Found {Count} results - skipping remaining {Remaining} fallback queries (rate limit optimization)",
-                    allResults.Count, queries.Count - queriesAttempted);
-                break;
+                logger.LogInformation("[SEARCH] Found {Count} results from query '{Query}' ({Total} total)",
+                    results.Count, query, allResults.Count);
             }
-
-            // Log progress if we found some results but not enough
-            if (allResults.Count > 0 && allResults.Count < MinimumResults)
+            else
             {
-                logger.LogInformation("[SEARCH] Found {Count} results (below minimum {Min}) - trying next query",
-                    allResults.Count, MinimumResults);
-            }
-            else if (allResults.Count == 0)
-            {
-                logger.LogWarning("[SEARCH] No results for query '{Query}' - trying next fallback", query);
+                logger.LogWarning("[SEARCH] No results for query '{Query}'", query);
             }
 
             // Hard limit: Stop at 100 total results

--- a/src/Services/AutomaticSearchService.cs
+++ b/src/Services/AutomaticSearchService.cs
@@ -264,23 +264,31 @@ public class AutomaticSearchService : IAutomaticSearchService
                     // Cached releases have Approved=true and empty Rejections by default
                     // We must run ReleaseEvaluator to apply CF minimum score and other profile requirements
                     await ReEvaluateCachedReleasesAsync(allReleases, qualityProfileId, part, evt.Sport, config.EnableMultiPartEpisodes, evt.Title, evt.League?.Tags);
+
+                    // Pre-populate seenGuids so supplementary queries below don't re-add cached releases
+                    foreach (var r in allReleases)
+                        if (!string.IsNullOrEmpty(r.Guid))
+                            seenGuids.Add(r.Guid);
                 }
             }
 
-            // If no cache hit, perform live search
-            if (!usedCache)
+            // Run all queries: live queries when no cache hit; supplementary queries always.
+            // Supplementary queries (Skip(1)) target alternative naming conventions (e.g. BILLIE-style
+            // F1 location releases) that the primary query may not reach. They must run even when the
+            // primary query hit the cache or returned enough results.
+            var queriesToRun = usedCache ? queries.Skip(1).ToList() : queries.ToList();
+
+            if (queriesToRun.Any())
             {
-                // Intelligent fallback search - try primary query first, exit early if no results
                 int queriesAttempted = 0;
                 int consecutiveEmptyResults = 0;
-                const int MinimumResults = 3;
                 const int MaxConsecutiveEmpty = 2;
 
-                foreach (var query in queries)
+                foreach (var query in queriesToRun)
                 {
                     queriesAttempted++;
                     _logger.LogInformation("[Automatic Search] Trying query {Attempt}/{Total}: '{Query}'",
-                        queriesAttempted, queries.Count, query);
+                        queriesAttempted, queriesToRun.Count, query);
 
                     // Pass part to indexer for proper filtering (with league tag-based indexer selection)
                     var leagueTags = evt.League?.Tags ?? new List<int>();
@@ -310,21 +318,14 @@ public class AutomaticSearchService : IAutomaticSearchService
                             }
                         }
 
-                        if (allReleases.Count >= MinimumResults)
-                        {
-                            _logger.LogInformation("[Automatic Search] Found {Count} results - skipping remaining {Remaining} fallback queries",
-                                allReleases.Count, queries.Count - queriesAttempted);
-                            break;
-                        }
-
-                        _logger.LogInformation("[Automatic Search] Found {Count} results so far (need {Min} minimum)",
-                            allReleases.Count, MinimumResults);
+                        _logger.LogInformation("[Automatic Search] Found {Count} results so far",
+                            allReleases.Count);
                     }
                 }
 
-                // Store results in cache for subsequent searches using the same query
+                // Store primary-query results in cache for subsequent searches
                 // This prevents redundant indexer queries when searching multiple events (e.g., F1 races)
-                if (allReleases.Any() && !string.IsNullOrEmpty(primaryQuery))
+                if (!usedCache && allReleases.Any() && !string.IsNullOrEmpty(primaryQuery))
                 {
                     _searchResultCache.Store(primaryQuery, allReleases);
                     _logger.LogDebug("[Automatic Search] Cached {Count} results for query '{Query}'",

--- a/src/Services/EventQueryService.cs
+++ b/src/Services/EventQueryService.cs
@@ -250,7 +250,11 @@ public class EventQueryService
     }
 
     /// <summary>
-    /// Build motorsport queries: specific (series + year + round) then broad (series + year).
+    /// Build motorsport queries: specific (series + year + round) then location fallbacks then broad (series + year).
+    ///
+    /// For Formula 1 the location-based queries are essential to find BILLIE-style releases
+    /// (e.g. Formula1.2026.China.Grand.Prix.Qualifying) which do not contain a round number and
+    /// are therefore invisible to the primary round query.
     /// </summary>
     private void BuildMotorsportQueries(Event evt, string? leagueName, List<string> queries)
     {
@@ -269,14 +273,32 @@ public class EventQueryService
         if (!string.IsNullOrEmpty(evt.Round) && int.TryParse(evt.Round, out var roundNum) && roundNum > 0 && roundNum < 100)
         {
             queries.Add($"{seriesPrefix} {year} Round{roundNum:D2}");
-            // Fallback: series + year only (broad — catches all naming variants)
-            queries.Add($"{seriesPrefix} {year}");
         }
-        else
+
+        // For Formula 1, add location-based supplementary queries to catch BILLIE-style releases
+        // (Formula1.2026.China.Grand.Prix) that don't use round numbers.
+        if (seriesPrefix == "Formula1")
         {
-            // No valid round — just series + year
-            queries.Add($"{seriesPrefix} {year}");
+            if (!string.IsNullOrEmpty(evt.Location))
+            {
+                queries.Add($"{seriesPrefix} {year} {evt.Location}");
+            }
+
+            // Also derive a location word from the event title (e.g. "Chinese" from "Chinese Grand Prix")
+            var titleLocationMatch = Regex.Match(evt.Title ?? "", @"^([\w\s]+?)\s+Grand Prix", RegexOptions.IgnoreCase);
+            if (titleLocationMatch.Success)
+            {
+                var titleWord = titleLocationMatch.Groups[1].Value.Trim();
+                if (!string.IsNullOrEmpty(titleWord) &&
+                    !string.Equals(titleWord, evt.Location, StringComparison.OrdinalIgnoreCase))
+                {
+                    queries.Add($"{seriesPrefix} {year} {titleWord}");
+                }
+            }
         }
+
+        // Broad fallback: series + year catches any remaining naming variants
+        queries.Add($"{seriesPrefix} {year}");
     }
 
     /// <summary>

--- a/src/Services/SportsFileNameParser.cs
+++ b/src/Services/SportsFileNameParser.cs
@@ -213,6 +213,7 @@ public class SportsFileNameParser
                 ? $"F1 {match.Groups["year"].Value} Round {match.Groups["round"].Value}: {match.Groups["name"].Value.Replace(".", " ")} GP"
                 : $"F1 {match.Groups["year"].Value} {match.Groups["name"].Value.Replace(".", " ")} GP",
             RoundExtractor = (match) => match.Groups["round"].Success && int.TryParse(match.Groups["round"].Value, out var r) ? r : (int?)null,
+            LocationExtractor = (match) => CleanLocationName(match.Groups["name"].Value),
             SessionExtractor = (match) => DetectMotorsportSession(match.Groups["name"].Value)
         },
 
@@ -690,6 +691,8 @@ public class SportsFileNameParser
         if (Regex.IsMatch(lower, @"\bshootout\b")) return "Sprint Qualifying";
         if (Regex.IsMatch(lower, @"\bqualifying\b|\bquali\b")) return "Qualifying";
         if (Regex.IsMatch(lower, @"\bwarm\s*up\b")) return "Warm Up";
+        // Pre-show programmes that are not race sessions (e.g. MotoGP "Gear Up" show)
+        if (Regex.IsMatch(lower, @"\bgear[\s\-_.]*up\b")) return "Pre-Show";
         // Race — grand prix/gp safe here because practice/qualifying/sprint already matched above
         if (Regex.IsMatch(lower, @"\brace\b|\bgrand\s*prix\b|\bgp\b(?!\s*of)")) return "Race";
         if (Regex.IsMatch(lower, @"\bpre\s*season\s+test")) return "Pre-Season Testing";


### PR DESCRIPTION
Fixes #103

## Summary

Four related bugs prevented Sportarr from finding Formula 1 releases that use a **location naming convention** (`Formula1.2026.China.Grand.Prix.Qualifying`) rather than the round-number convention (`Formula1.2026.Round02.China.FP1`). Additionally, MotoGP "Gear Up" pre-show releases were incorrectly matched to race events.

### Bug 1 — `SportsFileNameParser`: F1 pattern missing `LocationExtractor`

Every other motorsport pattern (MotoGP, IndyCar, WRC, WSBK, …) populates `SportsParseResult.Location` via a `LocationExtractor` delegate. The Formula 1 pattern was the only one without it, so BILLIE-style filenames returned `Location: N/A`.

**Fix:** Add `LocationExtractor = (match) => CleanLocationName(match.Groups["name"].Value)` to the F1 `SportsPattern`.

### Bug 2 — `EventQueryService`: no location fallback queries for F1

`BuildMotorsportQueries` only emitted a round-number query (`Formula1 2026 Round02`) and a broad fallback (`Formula1 2026`). Indexers serving only BILLIE-style releases return zero results for a round-number query.

**Fix:** When `seriesPrefix == "Formula1"`, add supplementary queries:
- `Formula1 {year} {evt.Location}` (e.g. `Formula1 2026 China`)
- A title-derived adjective form (e.g. `Formula1 2026 Chinese` from `"Chinese Grand Prix"` in `evt.Title`) when it differs from `evt.Location`

### Bug 3 — `AutomaticSearchService` / `Program.cs`: supplementary queries silently skipped

Two code paths prevented supplementary queries from running:
1. **Cache hit**: the entire search loop was skipped when the primary query was served from cache.
2. **Early-exit**: a `MinimumResults` threshold broke the loop as soon as ≥3 (auto) or ≥10 (manual) results accumulated, before location queries had a chance to run.

**Fix:** Restructure both search loops so supplementary queries (`queries.Skip(1)`) **always run** — on cache hit and after the primary live query. On a cache hit, `seenGuids` is pre-populated from cached results to prevent duplicates. The `MinimumResults` early-exit is removed; the consecutive-empty-results guard (`MaxConsecutiveEmpty = 2`) is retained to avoid unnecessary indexer calls when an event hasn't aired yet.

### Bug 4 — `SportsFileNameParser`: MotoGP "Gear Up" pre-show not detected

`DetectMotorsportSession` had no pattern for "Gear Up", causing `MotoGP.2026.Round03.USA.Gear.Up.WEB-DL` to fall through to the assumed-Race branch and match the USA GP race event incorrectly.

**Fix:** Add `\bgear[\s\-_.]*up\b` → `"Pre-Show"` before the Race branch. A session value of `"Pre-Show"` produces a session-mismatch rejection against the race event.

## Test plan

- [ ] Search for a monitored F1 event: verify both `Formula1 {year} Round{NN}` and `Formula1 {year} {Location}` queries are issued
- [ ] Manually trigger a search when primary query is already cached: confirm supplementary location queries still run and deduplicate correctly against cached results
- [ ] Add an indexer that returns BILLIE-style F1 releases; confirm they are found and imported for the correct event
- [ ] Add `MotoGP.2026.Round03.USA.Gear.Up.WEB-DL` to a watched folder: confirm it is rejected (session mismatch) and does not consume the USA GP race slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)