### PR TITLE
fix: Try to fix Sportarr losing track of torrents in transmission

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -5437,6 +5437,7 @@ app.MapPut("/api/downloadclient/{id:int}", async (int id, DownloadClient updated
     client.UrlBase = updatedClient.UrlBase;
     client.Category = updatedClient.Category;
     client.PostImportCategory = updatedClient.PostImportCategory;
+    client.Directory = updatedClient.Directory;
     client.UseSsl = updatedClient.UseSsl;
     client.DisableSslCertificateValidation = updatedClient.DisableSslCertificateValidation;
     client.Enabled = updatedClient.Enabled;

--- a/src/Services/EnhancedDownloadMonitorService.cs
+++ b/src/Services/EnhancedDownloadMonitorService.cs
@@ -35,6 +35,37 @@ public class EnhancedDownloadMonitorService : BackgroundService
         // Wait before starting to allow app to fully initialize
         await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
 
+        // Reset MissingFromClientCount for all active downloads on startup.
+        // This prevents stale counts from a previous shutdown from causing false "removed externally" removals.
+        // Counts are only meaningful within a single continuous run.
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<SportarrDbContext>();
+            var activeDownloads = await db.DownloadQueue
+                .Where(d => d.MissingFromClientCount > 0 &&
+                            d.Status != DownloadStatus.Imported &&
+                            d.Status != DownloadStatus.Failed)
+                .ToListAsync(stoppingToken);
+
+            if (activeDownloads.Count > 0)
+            {
+                _logger.LogInformation("[Enhanced Download Monitor] Resetting MissingFromClientCount for {Total} download(s) on startup (prevents false removal after restart)",
+                    activeDownloads.Count);
+                foreach (var d in activeDownloads)
+                {
+                    _logger.LogInformation("[Enhanced Download Monitor] Resetting MissingFromClientCount={Count} for '{Title}' on startup",
+                        d.MissingFromClientCount, d.Title);
+                    d.MissingFromClientCount = 0;
+                }
+                await db.SaveChangesAsync(stoppingToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[Enhanced Download Monitor] Failed to reset MissingFromClientCount on startup");
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -105,7 +136,8 @@ public class EnhancedDownloadMonitorService : BackgroundService
                     db,
                     enableCompletedHandling,
                     redownloadFailed,
-                    redownloadFailedFromInteractive);
+                    redownloadFailedFromInteractive,
+                    cancellationToken);
 
                 // Save changes after each successful download to prevent data loss
                 await db.SaveChangesAsync(cancellationToken);
@@ -139,7 +171,8 @@ public class EnhancedDownloadMonitorService : BackgroundService
         SportarrDbContext db,
         bool enableCompletedHandling,
         bool redownloadFailed,
-        bool redownloadFailedFromInteractive)
+        bool redownloadFailedFromInteractive,
+        CancellationToken cancellationToken)
     {
         // For ImportPending downloads, skip the download client check and just retry import
         // The download already completed on the client, we're just waiting for the file to be accessible
@@ -169,12 +202,15 @@ public class EnhancedDownloadMonitorService : BackgroundService
             download.DownloadClient,
             download.DownloadId);
 
+        _logger.LogDebug("[Enhanced Download Monitor] Polling download client for: {Title} (ID: {DownloadId}, MissingFromClientCount: {MissingCount})",
+            download.Title, download.DownloadId, download.MissingFromClientCount ?? 0);
+
         if (status == null)
         {
             // Download not found by ID - try finding by title (Decypharr/debrid proxy compatibility)
             // Debrid proxies may change the download ID/hash after processing
-            _logger.LogDebug("[Enhanced Download Monitor] Download not found by ID {DownloadId}, trying title match for: {Title}",
-                download.DownloadId, download.Title);
+            _logger.LogInformation("[Enhanced Download Monitor] Download not found by ID {DownloadId}, trying title match for: {Title} (MissingCount so far: {Count})",
+                download.DownloadId, download.Title, download.MissingFromClientCount ?? 0);
 
             var (titleMatchStatus, newDownloadId) = await downloadClientService.FindDownloadByTitleAsync(
                 download.DownloadClient,
@@ -196,6 +232,13 @@ public class EnhancedDownloadMonitorService : BackgroundService
                 // This happens when user deletes from download client directly instead of through Sportarr
                 // Sonarr removes the queue item immediately when the download disappears from the client
 
+                // Do NOT count this as "missing" if we're shutting down — the null could be from a cancelled HTTP request
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("[Enhanced Download Monitor] Download status check cancelled for '{Title}' - skipping missing count increment", download.Title);
+                    return;
+                }
+
                 // Track consecutive "not found" checks to avoid removing on transient issues
                 download.MissingFromClientCount = (download.MissingFromClientCount ?? 0) + 1;
 
@@ -203,8 +246,8 @@ public class EnhancedDownloadMonitorService : BackgroundService
                 {
                     // After 3 consecutive checks (~15 seconds), remove from queue
                     // This matches Sonarr behavior: downloads removed from client are removed from queue
-                    _logger.LogInformation("[Enhanced Download Monitor] Download removed from client externally, removing from queue: {Title}",
-                        download.Title);
+                    _logger.LogWarning("[Enhanced Download Monitor] Download not found in client for {Count} consecutive checks, removing from queue: {Title} (DownloadId: {DownloadId})",
+                        download.MissingFromClientCount, download.Title, download.DownloadId);
 
                     // Remove from queue (Sonarr-style auto-cleanup)
                     db.DownloadQueue.Remove(download);
@@ -213,9 +256,9 @@ public class EnhancedDownloadMonitorService : BackgroundService
                 }
                 else
                 {
-                    // First few "not found" - could be transient, log at debug level
-                    _logger.LogDebug("[Enhanced Download Monitor] Download not found in client (check {Count}/3): {Title}",
-                        download.MissingFromClientCount, download.Title);
+                    // First few "not found" checks — log at Warning so they are visible in production
+                    _logger.LogWarning("[Enhanced Download Monitor] Download not found in client (check {Count}/3): {Title} (DownloadId: {DownloadId})",
+                        download.MissingFromClientCount, download.Title, download.DownloadId);
                 }
                 return;
             }

--- a/src/Services/EnhancedDownloadMonitorService.cs
+++ b/src/Services/EnhancedDownloadMonitorService.cs
@@ -239,12 +239,22 @@ public class EnhancedDownloadMonitorService : BackgroundService
                     return;
                 }
 
+                // Grace period: newly added downloads may not be visible in client yet
+                // Transmission/other clients can take several minutes to register a torrent
+                var gracePeriod = TimeSpan.FromMinutes(3);
+                if (download.Added > DateTime.UtcNow - gracePeriod)
+                {
+                    _logger.LogDebug("[Enhanced Download Monitor] Download recently added ({Age:F0}s ago), skipping missing check during grace period: {Title}",
+                        (DateTime.UtcNow - download.Added).TotalSeconds, download.Title);
+                    return;
+                }
+
                 // Track consecutive "not found" checks to avoid removing on transient issues
                 download.MissingFromClientCount = (download.MissingFromClientCount ?? 0) + 1;
 
-                if (download.MissingFromClientCount >= 3)
+                if (download.MissingFromClientCount >= 10)
                 {
-                    // After 3 consecutive checks (~15 seconds), remove from queue
+                    // After 10 consecutive checks (e.g. ~5 minutes at 30s poll interval), remove from queue
                     // This matches Sonarr behavior: downloads removed from client are removed from queue
                     _logger.LogWarning("[Enhanced Download Monitor] Download not found in client for {Count} consecutive checks, removing from queue: {Title} (DownloadId: {DownloadId})",
                         download.MissingFromClientCount, download.Title, download.DownloadId);
@@ -257,7 +267,7 @@ public class EnhancedDownloadMonitorService : BackgroundService
                 else
                 {
                     // First few "not found" checks — log at Warning so they are visible in production
-                    _logger.LogWarning("[Enhanced Download Monitor] Download not found in client (check {Count}/3): {Title} (DownloadId: {DownloadId})",
+                    _logger.LogWarning("[Enhanced Download Monitor] Download not found in client (check {Count}/10): {Title} (DownloadId: {DownloadId})",
                         download.MissingFromClientCount, download.Title, download.DownloadId);
                 }
                 return;

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -258,7 +258,6 @@ public class TransmissionClient
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
-                    _logger.LogInformation("[Transmission] Torrent response", args.TryGetProperty("torrents", out var torrents));
                     return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
                 }
             }

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -254,7 +254,7 @@ public class TransmissionClient
             if (response != null)
             {
                 var doc = JsonDocument.Parse(response);
-                _logger.LogInformation("[Transmission] Json response", doc);
+                _logger.LogInformation("[Transmission] Json response {Doc}", doc);
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
@@ -333,9 +333,9 @@ public class TransmissionClient
         try
         {
             var torrents = await GetTorrentsByHashAsync(config, hash);
-            _logger.LogInformation("[Transmission] Returned torrents", torrents);
+            _logger.LogInformation("[Transmission] Returned torrents {Torrents}", torrents);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
-            _logger.LogInformation("[Transmission] Filtered torrents", torrent);
+            _logger.LogInformation("[Transmission] Filtered torrents {Torrent}", torrent);
             if (torrent == null)
                 return null;
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -245,10 +245,10 @@ public class TransmissionClient
             };
 
             var requestJson = JsonSerializer.Serialize(new { method = "torrent-get", arguments });
-            _logger.LogDebug("[Transmission] Requesting torrent-get by hash: {json}", requestJson);
+            _logger.LogInformation("[Transmission] Requesting torrent-get by hash: {json}", requestJson);
 
             var response = await SendRpcRequestAsync(config, "torrent-get", arguments);
-            _logger.LogDebug("[Transmission] Response for torrent-get by hash: {response}", response);
+            _logger.LogInformation("[Transmission] Response for torrent-get by hash: {response}", response);
 
             if (response != null)
             {

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -13,10 +12,9 @@ namespace Sportarr.Api.Services;
 /// </summary>
 public class TransmissionClient
 {
-    private static readonly ConcurrentDictionary<string, string> _sessionIds = new();
-
     private readonly HttpClient _httpClient;
     private readonly ILogger<TransmissionClient> _logger;
+    private string? _sessionId;
     private string? _baseUrl;
     private string? _authCredentials;
     private HttpClient? _customHttpClient; // For SSL bypass
@@ -114,34 +112,27 @@ public class TransmissionClient
             if (response != null)
             {
                 var doc = JsonDocument.Parse(response);
-                if (doc.RootElement.TryGetProperty("arguments", out var args))
+                if (doc.RootElement.TryGetProperty("arguments", out var args) &&
+                    args.TryGetProperty("torrent-added", out var torrent) &&
+                    torrent.TryGetProperty("hashString", out var hash))
                 {
-                    JsonElement? torrentElement = null;
-                    if (args.TryGetProperty("torrent-added", out var added))
-                        torrentElement = added;
-                    else if (args.TryGetProperty("torrent-duplicate", out var duplicate))
-                        torrentElement = duplicate;
+                    var hashString = hash.GetString();
+                    _logger.LogInformation("[Transmission] Torrent added: {Hash}", hashString);
 
-                    if (torrentElement.HasValue && torrentElement.Value.TryGetProperty("hashString", out var hash))
+                    // Apply per-torrent seed limits from indexer settings (matches Sonarr behavior)
+                    if (hashString != null && (seedRatioLimit.HasValue || seedTimeLimitMinutes.HasValue))
                     {
-                        var hashString = hash.GetString();
-                        _logger.LogInformation("[Transmission] Torrent added: {Hash}", hashString);
-
-                        // Apply per-torrent seed limits from indexer settings (matches Sonarr behavior)
-                        if (hashString != null && (seedRatioLimit.HasValue || seedTimeLimitMinutes.HasValue))
-                        {
-                            await SetTorrentSeedingConfigurationAsync(config, hashString, seedRatioLimit, seedTimeLimitMinutes);
-                        }
-
-                        // Handle ForceStarted state - use torrent-start-now to bypass queue
-                        if (config.InitialState == TorrentInitialState.ForceStarted && hashString != null)
-                        {
-                            _logger.LogInformation("[Transmission] Force starting torrent (InitialState=ForceStarted)");
-                            await ForceStartTorrentAsync(config, hashString);
-                        }
-
-                        return hashString;
+                        await SetTorrentSeedingConfigurationAsync(config, hashString, seedRatioLimit, seedTimeLimitMinutes);
                     }
+
+                    // Handle ForceStarted state - use torrent-start-now to bypass queue
+                    if (config.InitialState == TorrentInitialState.ForceStarted && hashString != null)
+                    {
+                        _logger.LogInformation("[Transmission] Force starting torrent (InitialState=ForceStarted)");
+                        await ForceStartTorrentAsync(config, hashString);
+                    }
+
+                    return hashString;
                 }
             }
 
@@ -161,11 +152,13 @@ public class TransmissionClient
     {
         try
         {
-            ConfigureClient(config);
+            var torrents = await GetTorrentsAsync(config);
+            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
+            if (torrent == null) return;
 
             var setArgs = new Dictionary<string, object>
             {
-                ["ids"] = new[] { hash }
+                ["ids"] = new[] { torrent.Id }
             };
 
             if (seedRatioLimit.HasValue && seedRatioLimit.Value > 0)
@@ -233,50 +226,11 @@ public class TransmissionClient
     }
 
     /// <summary>
-    /// Get torrent by hash (fetches only the matching torrent via ids filter)
-    /// </summary>
-    private async Task<List<TransmissionTorrent>?> GetTorrentsByHashAsync(DownloadClient config, string hash)
-    {
-        try
-        {
-            ConfigureClient(config);
-
-            var arguments = new
-            {
-                ids = new[] { hash },
-                fields = new[] { "id", "hashString", "name", "totalSize", "percentDone",
-                                "downloadedEver", "uploadedEver", "status", "eta",
-                                "rateDownload", "rateUpload", "downloadDir", "addedDate",
-                                "doneDate" }
-            };
-
-            var response = await SendRpcRequestAsync(config, "torrent-get", arguments);
-
-            if (response != null)
-            {
-                var doc = JsonDocument.Parse(response);
-                if (doc.RootElement.TryGetProperty("arguments", out var args) &&
-                    args.TryGetProperty("torrents", out var torrents))
-                {
-                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
-                }
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "[Transmission] Error getting torrent by hash");
-            return null;
-        }
-    }
-
-    /// <summary>
     /// Get torrent by hash
     /// </summary>
     public async Task<TransmissionTorrent?> GetTorrentAsync(DownloadClient config, string hash)
     {
-        var torrents = await GetTorrentsByHashAsync(config, hash);
+        var torrents = await GetTorrentsAsync(config);
         return torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -327,7 +281,7 @@ public class TransmissionClient
     {
         try
         {
-            var torrents = await GetTorrentsByHashAsync(config, hash);
+            var torrents = await GetTorrentsAsync(config);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
 
             if (torrent == null)
@@ -380,9 +334,15 @@ public class TransmissionClient
         {
             ConfigureClient(config);
 
+            // Find torrent ID by hash
+            var torrents = await GetTorrentsAsync(config);
+            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
+
+            if (torrent == null) return false;
+
             var arguments = new
             {
-                ids = new[] { hash },
+                ids = new[] { torrent.Id },
                 deleteLocalData = deleteFiles
             };
 
@@ -420,9 +380,6 @@ public class TransmissionClient
         try
         {
             var client = GetHttpClient(config);
-            var sessionKey = $"{_baseUrl ?? string.Empty}\0{_authCredentials ?? string.Empty}";
-            _sessionIds.TryGetValue(sessionKey, out var sessionId);
-
             var request = new
             {
                 method = method,
@@ -435,8 +392,8 @@ public class TransmissionClient
             {
                 Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
             };
-            if (!string.IsNullOrEmpty(sessionId))
-                requestMessage.Headers.Add("X-Transmission-Session-Id", sessionId);
+            if (!string.IsNullOrEmpty(_sessionId))
+                requestMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
             if (!string.IsNullOrEmpty(_authCredentials))
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 
@@ -447,8 +404,7 @@ public class TransmissionClient
             {
                 if (response.Headers.TryGetValues("X-Transmission-Session-Id", out var sessionIds))
                 {
-                    var newSessionId = sessionIds.FirstOrDefault() ?? string.Empty;
-                    _sessionIds[sessionKey] = newSessionId;
+                    _sessionId = sessionIds.FirstOrDefault();
                     _logger.LogInformation("[Transmission] Got new session ID");
 
                     // Retry with new session ID (must create new request message)
@@ -456,7 +412,7 @@ public class TransmissionClient
                     {
                         Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
                     };
-                    retryMessage.Headers.Add("X-Transmission-Session-Id", newSessionId);
+                    retryMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
                     if (!string.IsNullOrEmpty(_authCredentials))
                         retryMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 
@@ -485,9 +441,14 @@ public class TransmissionClient
         {
             ConfigureClient(config);
 
+            var torrents = await GetTorrentsAsync(config);
+            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
+
+            if (torrent == null) return false;
+
             var arguments = new
             {
-                ids = new[] { hash }
+                ids = new[] { torrent.Id }
             };
 
             var response = await SendRpcRequestAsync(config, method, arguments);

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -257,7 +257,15 @@ public class TransmissionClient
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
-                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
+                    var torrents = JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrentsElement.GetRawText());
+
+                    // === ADD THESE DEBUG LINES ===
+                    _logger.LogInformation("[Transmission][HASH DEBUG] Sought hash: '{0}'", hash);
+                    foreach (var t in torrents ?? new List<TransmissionTorrent>())
+                        _logger.LogInformation("[Transmission][HASH DEBUG] Torrent hashString: '{0}'", t.HashString);
+                    // === END DEBUG LINES ===
+                
+                    return torrents;
                 }
             }
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -154,6 +154,7 @@ public class TransmissionClient
         try
         {
             var torrents = await GetTorrentsAsync(config);
+            _logger.LogInformation("[Transmission] Comparing got hash {torrent.HashString} vs expected {expected}", torrent.HashString, hash);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
             if (torrent == null) return;
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -226,6 +226,50 @@ public class TransmissionClient
     }
 
     /// <summary>
+    /// Get torrent by hash (fetches only the matching torrent via ids filter)
+    /// </summary>
+    private async Task<List<TransmissionTorrent>?> GetTorrentsByHashAsync(DownloadClient config, string hash)
+    {
+        try
+        {
+            ConfigureClient(config);
+
+            var arguments = new
+            {
+                ids = new[] { hash },
+                fields = new[] { "id", "hashString", "name", "totalSize", "percentDone",
+                                "downloadedEver", "uploadedEver", "status", "eta",
+                                "rateDownload", "rateUpload", "downloadDir", "addedDate",
+                                "doneDate" }
+            };
+
+            var response = await SendRpcRequestAsync(config, "torrent-get", arguments);
+
+            if (response != null)
+            {
+                var doc = JsonDocument.Parse(response);
+                if (doc.RootElement.TryGetProperty("arguments", out var args) &&
+                    args.TryGetProperty("torrents", out var torrents))
+                {
+                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
+                }
+            }
+
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("[Transmission] Get torrents by hash cancelled (app shutting down or timeout): {Hash}", hash);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Transmission] Error getting torrent by hash: {Hash}", hash);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Get torrent by hash
     /// </summary>
     public async Task<TransmissionTorrent?> GetTorrentAsync(DownloadClient config, string hash)
@@ -428,9 +472,19 @@ public class TransmissionClient
             _logger.LogWarning("[Transmission] RPC request failed: {Status}", response.StatusCode);
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("[Transmission] RPC request cancelled (app shutting down or timeout): {Method}", method);
+            return null;
+        }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogWarning("[Transmission] RPC request cancelled - HttpClient disposed (app shutting down): {Method}", method);
+            return null;
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[Transmission] RPC request error");
+            _logger.LogError(ex, "[Transmission] RPC request error for method: {Method}", method);
             return null;
         }
     }

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -257,15 +257,7 @@ public class TransmissionClient
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
-                    var torrents = JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrentsElement.GetRawText());
-
-                    // === ADD THESE DEBUG LINES ===
-                    _logger.LogInformation("[Transmission][HASH DEBUG] Sought hash: '{0}'", hash);
-                    foreach (var t in torrents ?? new List<TransmissionTorrent>())
-                        _logger.LogInformation("[Transmission][HASH DEBUG] Torrent hashString: '{0}'", t.HashString);
-                    // === END DEBUG LINES ===
-                
-                    return torrents;
+                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
                 }
             }
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -332,8 +332,9 @@ public class TransmissionClient
         try
         {
             var torrents = await GetTorrentsByHashAsync(config, hash);
+            _logger.LogInformation("[Transmission] Returned torrents", torrents);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
-
+            _logger.LogInformation("[Transmission] Filtered torrents", torrent);
             if (torrent == null)
                 return null;
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -244,7 +244,11 @@ public class TransmissionClient
                                 "doneDate" }
             };
 
+            var requestJson = JsonSerializer.Serialize(new { method = "torrent-get", arguments });
+            _logger.LogDebug("[Transmission] Requesting torrent-get by hash: {json}", requestJson);
+
             var response = await SendRpcRequestAsync(config, "torrent-get", arguments);
+            _logger.LogDebug("[Transmission] Response for torrent-get by hash: {response}", response);
 
             if (response != null)
             {

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -12,9 +13,10 @@ namespace Sportarr.Api.Services;
 /// </summary>
 public class TransmissionClient
 {
+    private static readonly ConcurrentDictionary<string, string> _sessionIds = new();
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<TransmissionClient> _logger;
-    private string? _sessionId;
     private string? _baseUrl;
     private string? _authCredentials;
     private HttpClient? _customHttpClient; // For SSL bypass
@@ -112,27 +114,34 @@ public class TransmissionClient
             if (response != null)
             {
                 var doc = JsonDocument.Parse(response);
-                if (doc.RootElement.TryGetProperty("arguments", out var args) &&
-                    args.TryGetProperty("torrent-added", out var torrent) &&
-                    torrent.TryGetProperty("hashString", out var hash))
+                if (doc.RootElement.TryGetProperty("arguments", out var args))
                 {
-                    var hashString = hash.GetString();
-                    _logger.LogInformation("[Transmission] Torrent added: {Hash}", hashString);
+                    JsonElement? torrentElement = null;
+                    if (args.TryGetProperty("torrent-added", out var added))
+                        torrentElement = added;
+                    else if (args.TryGetProperty("torrent-duplicate", out var duplicate))
+                        torrentElement = duplicate;
 
-                    // Apply per-torrent seed limits from indexer settings (matches Sonarr behavior)
-                    if (hashString != null && (seedRatioLimit.HasValue || seedTimeLimitMinutes.HasValue))
+                    if (torrentElement.HasValue && torrentElement.Value.TryGetProperty("hashString", out var hash))
                     {
-                        await SetTorrentSeedingConfigurationAsync(config, hashString, seedRatioLimit, seedTimeLimitMinutes);
-                    }
+                        var hashString = hash.GetString();
+                        _logger.LogInformation("[Transmission] Torrent added: {Hash}", hashString);
 
-                    // Handle ForceStarted state - use torrent-start-now to bypass queue
-                    if (config.InitialState == TorrentInitialState.ForceStarted && hashString != null)
-                    {
-                        _logger.LogInformation("[Transmission] Force starting torrent (InitialState=ForceStarted)");
-                        await ForceStartTorrentAsync(config, hashString);
-                    }
+                        // Apply per-torrent seed limits from indexer settings (matches Sonarr behavior)
+                        if (hashString != null && (seedRatioLimit.HasValue || seedTimeLimitMinutes.HasValue))
+                        {
+                            await SetTorrentSeedingConfigurationAsync(config, hashString, seedRatioLimit, seedTimeLimitMinutes);
+                        }
 
-                    return hashString;
+                        // Handle ForceStarted state - use torrent-start-now to bypass queue
+                        if (config.InitialState == TorrentInitialState.ForceStarted && hashString != null)
+                        {
+                            _logger.LogInformation("[Transmission] Force starting torrent (InitialState=ForceStarted)");
+                            await ForceStartTorrentAsync(config, hashString);
+                        }
+
+                        return hashString;
+                    }
                 }
             }
 
@@ -152,13 +161,11 @@ public class TransmissionClient
     {
         try
         {
-            var torrents = await GetTorrentsAsync(config);
-            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
-            if (torrent == null) return;
+            ConfigureClient(config);
 
             var setArgs = new Dictionary<string, object>
             {
-                ["ids"] = new[] { torrent.Id }
+                ["ids"] = new[] { hash }
             };
 
             if (seedRatioLimit.HasValue && seedRatioLimit.Value > 0)
@@ -226,11 +233,50 @@ public class TransmissionClient
     }
 
     /// <summary>
+    /// Get torrent by hash (fetches only the matching torrent via ids filter)
+    /// </summary>
+    private async Task<List<TransmissionTorrent>?> GetTorrentsByHashAsync(DownloadClient config, string hash)
+    {
+        try
+        {
+            ConfigureClient(config);
+
+            var arguments = new
+            {
+                ids = new[] { hash },
+                fields = new[] { "id", "hashString", "name", "totalSize", "percentDone",
+                                "downloadedEver", "uploadedEver", "status", "eta",
+                                "rateDownload", "rateUpload", "downloadDir", "addedDate",
+                                "doneDate" }
+            };
+
+            var response = await SendRpcRequestAsync(config, "torrent-get", arguments);
+
+            if (response != null)
+            {
+                var doc = JsonDocument.Parse(response);
+                if (doc.RootElement.TryGetProperty("arguments", out var args) &&
+                    args.TryGetProperty("torrents", out var torrents))
+                {
+                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Transmission] Error getting torrent by hash");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Get torrent by hash
     /// </summary>
     public async Task<TransmissionTorrent?> GetTorrentAsync(DownloadClient config, string hash)
     {
-        var torrents = await GetTorrentsAsync(config);
+        var torrents = await GetTorrentsByHashAsync(config, hash);
         return torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -281,7 +327,7 @@ public class TransmissionClient
     {
         try
         {
-            var torrents = await GetTorrentsAsync(config);
+            var torrents = await GetTorrentsByHashAsync(config, hash);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
 
             if (torrent == null)
@@ -334,15 +380,9 @@ public class TransmissionClient
         {
             ConfigureClient(config);
 
-            // Find torrent ID by hash
-            var torrents = await GetTorrentsAsync(config);
-            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
-
-            if (torrent == null) return false;
-
             var arguments = new
             {
-                ids = new[] { torrent.Id },
+                ids = new[] { hash },
                 deleteLocalData = deleteFiles
             };
 
@@ -380,6 +420,9 @@ public class TransmissionClient
         try
         {
             var client = GetHttpClient(config);
+            var sessionKey = $"{_baseUrl ?? string.Empty}\0{_authCredentials ?? string.Empty}";
+            _sessionIds.TryGetValue(sessionKey, out var sessionId);
+
             var request = new
             {
                 method = method,
@@ -392,8 +435,8 @@ public class TransmissionClient
             {
                 Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
             };
-            if (!string.IsNullOrEmpty(_sessionId))
-                requestMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
+            if (!string.IsNullOrEmpty(sessionId))
+                requestMessage.Headers.Add("X-Transmission-Session-Id", sessionId);
             if (!string.IsNullOrEmpty(_authCredentials))
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 
@@ -404,7 +447,8 @@ public class TransmissionClient
             {
                 if (response.Headers.TryGetValues("X-Transmission-Session-Id", out var sessionIds))
                 {
-                    _sessionId = sessionIds.FirstOrDefault();
+                    var newSessionId = sessionIds.FirstOrDefault() ?? string.Empty;
+                    _sessionIds[sessionKey] = newSessionId;
                     _logger.LogInformation("[Transmission] Got new session ID");
 
                     // Retry with new session ID (must create new request message)
@@ -412,7 +456,7 @@ public class TransmissionClient
                     {
                         Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
                     };
-                    retryMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
+                    retryMessage.Headers.Add("X-Transmission-Session-Id", newSessionId);
                     if (!string.IsNullOrEmpty(_authCredentials))
                         retryMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 
@@ -441,14 +485,9 @@ public class TransmissionClient
         {
             ConfigureClient(config);
 
-            var torrents = await GetTorrentsAsync(config);
-            var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
-
-            if (torrent == null) return false;
-
             var arguments = new
             {
-                ids = new[] { torrent.Id }
+                ids = new[] { hash }
             };
 
             var response = await SendRpcRequestAsync(config, method, arguments);

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -254,9 +254,11 @@ public class TransmissionClient
             if (response != null)
             {
                 var doc = JsonDocument.Parse(response);
+                _logger.LogInformation("[Transmission] Json response", doc);
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
+                    _logger.LogInformation("[Transmission] Torrent response", args.TryGetProperty("torrents", out var torrents));
                     return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
                 }
             }

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -14,7 +15,7 @@ public class TransmissionClient
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<TransmissionClient> _logger;
-    private string? _sessionId;
+    private static readonly ConcurrentDictionary<string, string> _sessionIds = new();
     private string? _baseUrl;
     private string? _authCredentials;
     private HttpClient? _customHttpClient; // For SSL bypass
@@ -325,7 +326,7 @@ public class TransmissionClient
     {
         try
         {
-            var torrents = await GetTorrentsAsync(config);
+            var torrents = await GetTorrentsByHashAsync(config, hash);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
 
             if (torrent == null)
@@ -432,12 +433,15 @@ public class TransmissionClient
 
             var requestJson = JsonSerializer.Serialize(request);
 
+            var sessionKey = $"{_baseUrl ?? string.Empty}\0{_authCredentials ?? string.Empty}";
+            _sessionIds.TryGetValue(sessionKey, out var sessionId);
+
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, _baseUrl)
             {
                 Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
             };
-            if (!string.IsNullOrEmpty(_sessionId))
-                requestMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
+            if (!string.IsNullOrEmpty(sessionId))
+                requestMessage.Headers.Add("X-Transmission-Session-Id", sessionId);
             if (!string.IsNullOrEmpty(_authCredentials))
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 
@@ -448,7 +452,14 @@ public class TransmissionClient
             {
                 if (response.Headers.TryGetValues("X-Transmission-Session-Id", out var sessionIds))
                 {
-                    _sessionId = sessionIds.FirstOrDefault();
+                    var newSessionId = sessionIds.FirstOrDefault();
+                    if (string.IsNullOrEmpty(newSessionId))
+                    {
+                        _logger.LogWarning("[Transmission] 409 received but no session ID in response headers");
+                        return null;
+                    }
+
+                    _sessionIds[sessionKey] = newSessionId;
                     _logger.LogInformation("[Transmission] Got new session ID");
 
                     // Retry with new session ID (must create new request message)
@@ -456,7 +467,7 @@ public class TransmissionClient
                     {
                         Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
                     };
-                    retryMessage.Headers.Add("X-Transmission-Session-Id", _sessionId);
+                    retryMessage.Headers.Add("X-Transmission-Session-Id", newSessionId);
                     if (!string.IsNullOrEmpty(_authCredentials))
                         retryMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", _authCredentials);
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -16,6 +16,10 @@ public class TransmissionClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<TransmissionClient> _logger;
     private static readonly ConcurrentDictionary<string, string> _sessionIds = new();
+    private static readonly JsonSerializerOptions _transmissionJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
     private string? _baseUrl;
     private string? _authCredentials;
     private HttpClient? _customHttpClient; // For SSL bypass
@@ -214,7 +218,7 @@ public class TransmissionClient
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
-                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
+                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText(), _transmissionJsonOptions);
                 }
             }
 
@@ -258,7 +262,8 @@ public class TransmissionClient
                 if (doc.RootElement.TryGetProperty("arguments", out var args) &&
                     args.TryGetProperty("torrents", out var torrents))
                 {
-                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText());
+                    _logger.LogInformation("[Transmission] Raw torrents JSON: {TorrentsJson}", torrents.GetRawText());
+                    return JsonSerializer.Deserialize<List<TransmissionTorrent>>(torrents.GetRawText(), _transmissionJsonOptions);
                 }
             }
 

--- a/src/Services/TransmissionClient.cs
+++ b/src/Services/TransmissionClient.cs
@@ -154,8 +154,8 @@ public class TransmissionClient
         try
         {
             var torrents = await GetTorrentsAsync(config);
-            _logger.LogInformation("[Transmission] Comparing got hash {torrent.HashString} vs expected {expected}", torrent.HashString, hash);
             var torrent = torrents?.FirstOrDefault(t => t.HashString.Equals(hash, StringComparison.OrdinalIgnoreCase));
+            _logger.LogInformation("[Transmission] Comparing got hash {torrent.HashString} vs expected {expected}", torrent.HashString, hash);
             if (torrent == null) return;
 
             var setArgs = new Dictionary<string, object>


### PR DESCRIPTION
Hey @Sportarr !

Lately I've been trying to download some torrents using sportarr and eventhough now the directory override works well, while the download is running, Sportarr seems to lose the tracking of the torrent in transmission due to the following error:
```
[2026-04-03 14:25:45.465 +02:00] [INF] [Enhanced Download Monitor] Download removed from client externally, removing from queue: NBA RS 2026 Chicago Bulls vs Oklahoma City Thunder 27/03 720pEN60fps FDSNOK
```
In this PR i try to add the following thing:

- A new handler for the case we try to add to transmission a torrent that is already present inside it
- Instead of grabbing all torrents, we only grab the right one when possible
- Trying to implement a better thread handling to hopefully fix the issue above

⚠️ I did not tested this PR yet. Setting a local Sportarr with local transmission etc take too much time and I didn't find it yet ⚠️

Hopefully this help,
Regards

