### PR TITLE
feat(sabnzbd): pass canonical release name as `nzbname`

### DIFF
--- a/src/Services/DownloadClientService.cs
+++ b/src/Services/DownloadClientService.cs
@@ -238,11 +238,11 @@ public class DownloadClientService : IDownloadClientService
                 DownloadClientType.Transmission => WrapLegacyResult(await AddToTransmissionAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes)),
                 DownloadClientType.Deluge => WrapLegacyResult(await AddToDelugeAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes)),
                 DownloadClientType.RTorrent => WrapLegacyResult(await AddToRTorrentAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes)),
-                DownloadClientType.Sabnzbd => WrapLegacyResult(await AddToSabnzbdAsync(config, url, category)),
+                DownloadClientType.Sabnzbd => WrapLegacyResult(await AddToSabnzbdAsync(config, url, category, expectedName)),
                 DownloadClientType.NzbGet => WrapLegacyResult(await AddToNzbGetAsync(config, url, category)),
                 DownloadClientType.Decypharr => await AddToDecypharrWithResultAsync(config, url, category, expectedName, seedRatioLimit, seedTimeLimitMinutes),
-                DownloadClientType.DecypharrUsenet => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category)), // Decypharr usenet uses SABnzbd API emulation - must use URL mode so Decypharr can intercept
-                DownloadClientType.NZBdav => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category)), // NZBdav uses SABnzbd API but only supports addurl mode (not addfile)
+                DownloadClientType.DecypharrUsenet => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category, expectedName)), // Decypharr usenet uses SABnzbd API emulation - must use URL mode so Decypharr can intercept
+                DownloadClientType.NZBdav => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category, expectedName)), // NZBdav uses SABnzbd API but only supports addurl mode (not addfile)
                 _ => AddDownloadResult.Failed($"Download client type {config.Type} not supported", AddDownloadErrorType.Unknown)
             };
 
@@ -564,10 +564,13 @@ public class DownloadClientService : IDownloadClientService
         return await client.AddTorrentAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes);
     }
 
-    private async Task<string?> AddToSabnzbdAsync(DownloadClient config, string url, string category)
+    private async Task<string?> AddToSabnzbdAsync(DownloadClient config, string url, string category, string? expectedName = null)
     {
         var client = GetSabnzbdClient(config);
-        var nzoId = await client.AddNzbAsync(config, url, category);
+        // Thread the indexer's canonical release title through as `nzbname` so the
+        // download client doesn't fall back to the (often hash-based) Content-
+        // Disposition filename or the NZB's per-file obfuscated names.
+        var nzoId = await client.AddNzbAsync(config, url, category, expectedName);
         return nzoId;
     }
 
@@ -575,10 +578,10 @@ public class DownloadClientService : IDownloadClientService
     /// Add NZB via URL only - for Decypharr and other proxies that need to intercept the URL
     /// Unlike AddToSabnzbdAsync, this method doesn't fetch the NZB content first
     /// </summary>
-    private async Task<string?> AddToSabnzbdViaUrlAsync(DownloadClient config, string url, string category)
+    private async Task<string?> AddToSabnzbdViaUrlAsync(DownloadClient config, string url, string category, string? expectedName = null)
     {
         var client = GetSabnzbdClient(config);
-        var nzoId = await client.AddNzbViaUrlOnlyAsync(config, url, category);
+        var nzoId = await client.AddNzbViaUrlOnlyAsync(config, url, category, expectedName);
         return nzoId;
     }
 

--- a/src/Services/DownloadClients/BaseDownloadClient.cs
+++ b/src/Services/DownloadClients/BaseDownloadClient.cs
@@ -175,7 +175,7 @@ public interface ITorrentClient
 public interface IUsenetClient
 {
     Task<bool> TestConnectionAsync(DownloadClient config);
-    Task<string?> AddNzbAsync(DownloadClient config, string nzbUrl, string category);
+    Task<string?> AddNzbAsync(DownloadClient config, string nzbUrl, string category, string? nzbname = null);
     Task<bool> DeleteDownloadAsync(DownloadClient config, string nzoId, bool deleteFiles);
     Task<bool> PauseDownloadAsync(DownloadClient config, string nzoId);
     Task<bool> ResumeDownloadAsync(DownloadClient config, string nzoId);

--- a/src/Services/SabnzbdClient.cs
+++ b/src/Services/SabnzbdClient.cs
@@ -41,7 +41,7 @@ public class SabnzbdClient
     /// Uses raw byte handling to preserve encoding (ISO-8859-1 NZB files)
     /// Falls back to addurl mode if fetch fails or content is invalid
     /// </summary>
-    public async Task<string?> AddNzbAsync(DownloadClient config, string nzbUrl, string category)
+    public async Task<string?> AddNzbAsync(DownloadClient config, string nzbUrl, string category, string? nzbname = null)
     {
         try
         {
@@ -57,7 +57,7 @@ public class SabnzbdClient
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("[SABnzbd] Failed to fetch NZB: HTTP {StatusCode}. Falling back to addurl mode.", response.StatusCode);
-                return await AddNzbViaUrlAsync(config, nzbUrl, category);
+                return await AddNzbViaUrlAsync(config, nzbUrl, category, nzbname);
             }
 
             // Read as raw bytes - do NOT convert to string to avoid encoding issues
@@ -72,17 +72,17 @@ public class SabnzbdClient
             {
                 _logger.LogWarning("[SABnzbd] Invalid NZB content: {Reason}. Content preview: {Preview}. Falling back to addurl mode.",
                     validationResult.Reason, validationResult.ContentPreview);
-                return await AddNzbViaUrlAsync(config, nzbUrl, category);
+                return await AddNzbViaUrlAsync(config, nzbUrl, category, nzbname);
             }
 
             // Upload the raw bytes to SABnzbd
-            var result = await AddNzbViaContentAsync(config, nzbBytes, filename, category);
+            var result = await AddNzbViaContentAsync(config, nzbBytes, filename, category, nzbname);
 
             // If addfile fails, fall back to addurl mode
             if (result == null)
             {
                 _logger.LogWarning("[SABnzbd] addfile mode failed. Falling back to addurl mode.");
-                return await AddNzbViaUrlAsync(config, nzbUrl, category);
+                return await AddNzbViaUrlAsync(config, nzbUrl, category, nzbname);
             }
 
             return result;
@@ -92,7 +92,7 @@ public class SabnzbdClient
             _logger.LogError(ex, "[SABnzbd] Error adding NZB via addfile. Falling back to addurl mode.");
             try
             {
-                return await AddNzbViaUrlAsync(config, nzbUrl, category);
+                return await AddNzbViaUrlAsync(config, nzbUrl, category, nzbname);
             }
             catch (Exception fallbackEx)
             {
@@ -149,7 +149,7 @@ public class SabnzbdClient
     /// Add NZB via content - uploads raw bytes to SABnzbd
     /// Uses multipart form upload to preserve original file encoding (ISO-8859-1)
     /// </summary>
-    private async Task<string?> AddNzbViaContentAsync(DownloadClient config, byte[] nzbBytes, string filename, string category)
+    private async Task<string?> AddNzbViaContentAsync(DownloadClient config, byte[] nzbBytes, string filename, string category, string? nzbname = null)
     {
         var protocol = config.UseSsl ? "https" : "http";
         var urlBase = config.UrlBase ?? "";
@@ -166,6 +166,16 @@ public class SabnzbdClient
         content.Add(new StringContent(apiKey), "apikey");
         content.Add(new StringContent("json"), "output");
         content.Add(new StringContent(category), "cat");
+
+        // Pass the canonical release name as `nzbname` so SABnzbd-compatible targets
+        // use it instead of falling back to the multipart filename (which is often
+        // an indexer-provided hash) or the per-file yenc names (commonly obfuscated).
+        // SABnzbd documents this as the public name override:
+        // https://sabnzbd.org/wiki/configuration/4.4/api#addfile
+        if (!string.IsNullOrWhiteSpace(nzbname))
+        {
+            content.Add(new StringContent(nzbname), "nzbname");
+        }
 
         if (!string.IsNullOrWhiteSpace(config.Directory))
         {
@@ -241,23 +251,23 @@ public class SabnzbdClient
     /// Add NZB via URL only - for use with Decypharr and other proxies that need to intercept the URL
     /// This skips the fetch-and-upload approach and directly passes the URL to the download client
     /// </summary>
-    public async Task<string?> AddNzbViaUrlOnlyAsync(DownloadClient config, string nzbUrl, string category)
+    public async Task<string?> AddNzbViaUrlOnlyAsync(DownloadClient config, string nzbUrl, string category, string? nzbname = null)
     {
         _logger.LogInformation("[SABnzbd] Adding NZB via URL (proxy mode) to {Name}", config.Name);
         _logger.LogInformation("[SABnzbd] Config check: Id={Id}, Host={Host}, Port={Port}, HasApiKey={HasApiKey}, ApiKeyLength={ApiKeyLength}",
             config.Id, config.Host, config.Port,
             !string.IsNullOrWhiteSpace(config.ApiKey),
             config.ApiKey?.Length ?? 0);
-        return await AddNzbViaUrlAsync(config, nzbUrl, category);
+        return await AddNzbViaUrlAsync(config, nzbUrl, category, nzbname);
     }
 
     /// <summary>
     /// Fallback method: Add NZB via URL (original behavior for when fetch fails)
     /// </summary>
-    private async Task<string?> AddNzbViaUrlAsync(DownloadClient config, string nzbUrl, string category)
+    private async Task<string?> AddNzbViaUrlAsync(DownloadClient config, string nzbUrl, string category, string? nzbname = null)
     {
         _logger.LogDebug("[SABnzbd] Using addurl fallback mode");
-        var response = await SendAddUrlRequestAsync(config, nzbUrl, category);
+        var response = await SendAddUrlRequestAsync(config, nzbUrl, category, nzbname);
 
         if (response != null)
         {
@@ -869,7 +879,7 @@ public class SabnzbdClient
     /// Returns: (response, shouldFallbackToUrl) - shouldFallbackToUrl is true when addfile mode isn't supported.
     /// </summary>
     private async Task<(string? Response, bool ShouldFallbackToUrl)> SendAddFileRequestAsync(
-        DownloadClient config, byte[] nzbData, string filename, string category, string originalUrl)
+        DownloadClient config, byte[] nzbData, string filename, string category, string originalUrl, string? nzbname = null)
     {
         try
         {
@@ -908,6 +918,14 @@ public class SabnzbdClient
             {
                 content.Add(new StringContent(config.Username), "ma_username");
                 content.Add(new StringContent(config.Password), "ma_password");
+            }
+
+            // Pass nzbname so the receiver overrides the (often obscured) upload
+            // filename with the canonical release name. See AddNzbViaContentAsync
+            // for context.
+            if (!string.IsNullOrWhiteSpace(nzbname))
+            {
+                content.Add(new StringContent(nzbname), "nzbname");
             }
 
             // Add NZB file content
@@ -959,7 +977,7 @@ public class SabnzbdClient
     /// <summary>
     /// Send POST request for addurl mode (required by Decypharr and some SABnzbd configurations)
     /// </summary>
-    private async Task<string?> SendAddUrlRequestAsync(DownloadClient config, string nzbUrl, string category)
+    private async Task<string?> SendAddUrlRequestAsync(DownloadClient config, string nzbUrl, string category, string? nzbname = null)
     {
         try
         {
@@ -985,6 +1003,13 @@ public class SabnzbdClient
                 { "cat", category },
                 { "output", "json" }
             };
+
+            // Pass the canonical release name so SABnzbd labels the download with
+            // it rather than parsing the (often hash-named) URL.
+            if (!string.IsNullOrWhiteSpace(nzbname))
+            {
+                formData["nzbname"] = nzbname;
+            }
 
             if (!string.IsNullOrWhiteSpace(config.Directory))
             {


### PR DESCRIPTION
## Summary

- Plumbs the canonical release name (already known on the call site as `expectedName`) through the SABnzbd download client and onto the wire as the `nzbname` form field on every request path (`mode=addfile` and `mode=addurl`).
- Non-breaking: `IUsenetClient.AddNzbAsync` gains an *optional* `nzbname` parameter so other implementations (`NzbGetClient` etc.) are untouched.

## Why

Sportarr already passes the indexer's canonical release title to the QBittorrent download client as `expectedName`, and it benefits from the cleaner naming on disk. The SABnzbd path silently dropped that information, so the receiving server had to fall back to:

1. the **multipart upload filename** — for Prowlarr-served NZBs, the indexer returns a `Content-Disposition` with a hash-based name (e.g. `3709r79e19m1m1m18m23a15h85z04853.mkv.nzb`), or
2. the **per-file yenc names inside the NZB** — frequently obfuscated by uploaders to evade DMCA scrapers (e.g. `oYBVxskQWIaXbaZLlbhl55MS78I05WgC.mp4`)

…which leaves the on-disk release named after gibberish for a substantial fraction of grabs. The canonical name *exists* in Sportarr's search result; it just wasn't being passed downstream.

SABnzbd documents `nzbname` as the explicit release-name override and gives it priority over filename-derived names: https://sabnzbd.org/wiki/configuration/4.4/api#addfile — every SABnzbd-API-compatible target (SABnzbd itself, NZBdav, Decypharr-usenet, debridav, etc.) honours it.

## What changed

| File | Change |
|---|---|
| `src/Services/DownloadClients/BaseDownloadClient.cs` | `IUsenetClient.AddNzbAsync` gains optional `nzbname` parameter |
| `src/Services/SabnzbdClient.cs` | `AddNzbAsync`, `AddNzbViaContentAsync`, `AddNzbViaUrlAsync`, `AddNzbViaUrlOnlyAsync`, `SendAddFileRequestAsync`, `SendAddUrlRequestAsync` all accept `nzbname` and add it as a form field when non-empty |
| `src/Services/DownloadClientService.cs` | `AddToSabnzbdAsync` / `AddToSabnzbdViaUrlAsync` accept `expectedName` and pass it through; `AddDownloadWithResultAsync`'s switch passes the already-available `expectedName` |

Diff: **3 files changed, +49 / −21**, no behaviour change when `nzbname` isn't supplied.

## Test plan

- [x] Compiles clean (release config, `dotnet publish -c Release -r linux-x64`)
- [x] Verified end-to-end against a real SABnzbd-API-compatible target (debridav): grabbed a UFC release through Prowlarr whose download URL serves a hash-named NZB, and confirmed via server-side logs that the request body now includes `nzbname=UFC.Fight.Night.<...>.WEB-DL.H264-Fight-BB` — the download appears in the queue under its canonical name rather than the hash, and the on-disk path matches the search-result title.
- [x] No behaviour change verified for `mode=addfile` when `expectedName` is null (the field is conditionally added behind a `IsNullOrWhiteSpace` check).
- [x] Existing `AddNzbViaUrlOnlyAsync` callers (Decypharr-usenet, NZBdav) get the same benefit since they thread through the same path.

## Notes

- `NzbGetClient.AddNzbAsync` was intentionally not modified — NZBGet's API has its own naming knobs and the equivalent isn't a one-line change; happy to follow up in a separate PR if maintainers want symmetry.
- I'll sign the CLA on the next push if not already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)