### PR TITLE
JF/Emby Agents Feature: ExternalId Provider Ids

### DIFF
--- a/agents/emby/Sportarr/Providers/SportarrExternalIdProvider.cs
+++ b/agents/emby/Sportarr/Providers/SportarrExternalIdProvider.cs
@@ -1,0 +1,72 @@
+namespace Sportarr.Providers
+{
+    using MediaBrowser.Controller.Entities.TV;
+    using MediaBrowser.Controller.Providers;
+    using MediaBrowser.Model.Entities;
+
+    /// <summary>
+    /// Registers the Sportarr provider ID as a known external identifier for series.
+    /// This surfaces the stored "Sportarr" provider ID (e.g. "lg-000028") as a labelled
+    /// field in the Emby metadata editor, alongside IMDb/TheTVDB IDs. The value is shown
+    /// as plain text; no click-through URL is provided.
+    /// </summary>
+    public class SportarrSeriesExternalId : IExternalId
+    {
+        /// <summary>
+        /// Gets the display label shown for this external ID in the metadata editor.
+        /// </summary>
+        public string Name => "Sportarr";
+
+        /// <summary>
+        /// Gets the provider key. Must match the key used by SetProviderId("Sportarr", ...)
+        /// so the editor field binds to the stored value.
+        /// </summary>
+        public string Key => "Sportarr";
+
+        /// <summary>
+        /// Gets the URL format string for linking out to the ID. The "{0}" placeholder
+        /// is replaced with the stored Sportarr ID to produce a clickable link.
+        /// </summary>
+        public string UrlFormatString => "https://sportarr.net/api/metadata/agents/series/{0}";
+
+        /// <summary>
+        /// Determines whether this external ID applies to the given item.
+        /// </summary>
+        /// <param name="item">The item to test.</param>
+        /// <returns>True for <see cref="Series"/> items; otherwise false.</returns>
+        public bool Supports(IHasProviderIds item) => item is Series;
+    }
+
+    /// <summary>
+    /// Registers the Sportarr provider ID as a known external identifier for episodes (matches/events).
+    /// This surfaces the stored "Sportarr" provider ID as a labelled field in the Emby metadata
+    /// editor, alongside IMDb/TheTVDB IDs. The value is shown as plain text; no click-through URL
+    /// is provided.
+    /// </summary>
+    public class SportarrEpisodeExternalId : IExternalId
+    {
+        /// <summary>
+        /// Gets the display label shown for this external ID in the metadata editor.
+        /// </summary>
+        public string Name => "Sportarr";
+
+        /// <summary>
+        /// Gets the provider key. Must match the key used by SetProviderId("Sportarr", ...)
+        /// so the editor field binds to the stored value.
+        /// </summary>
+        public string Key => "Sportarr";
+
+        /// <summary>
+        /// Gets the URL format string for linking out to the ID. The "{0}" placeholder
+        /// is replaced with the stored Sportarr ID to produce a clickable link.
+        /// </summary>
+        public string UrlFormatString => "https://sportarr.net/api/metadata/agents/episode/{0}";
+
+        /// <summary>
+        /// Determines whether this external ID applies to the given item.
+        /// </summary>
+        /// <param name="item">The item to test.</param>
+        /// <returns>True for <see cref="Episode"/> items; otherwise false.</returns>
+        public bool Supports(IHasProviderIds item) => item is Episode;
+    }
+}

--- a/agents/emby/Sportarr/Providers/SportarrExternalIdProvider.cs
+++ b/agents/emby/Sportarr/Providers/SportarrExternalIdProvider.cs
@@ -8,7 +8,7 @@ namespace Sportarr.Providers
     /// Registers the Sportarr provider ID as a known external identifier for series.
     /// This surfaces the stored "Sportarr" provider ID (e.g. "lg-000028") as a labelled
     /// field in the Emby metadata editor, alongside IMDb/TheTVDB IDs. The value is shown
-    /// as plain text; no click-through URL is provided.
+    /// as plain text; The click-through URL points to the Sportarr API Series (League).
     /// </summary>
     public class SportarrSeriesExternalId : IExternalId
     {
@@ -40,8 +40,8 @@ namespace Sportarr.Providers
     /// <summary>
     /// Registers the Sportarr provider ID as a known external identifier for episodes (matches/events).
     /// This surfaces the stored "Sportarr" provider ID as a labelled field in the Emby metadata
-    /// editor, alongside IMDb/TheTVDB IDs. The value is shown as plain text; no click-through URL
-    /// is provided.
+    /// editor, alongside IMDb/TheTVDB IDs. The click-through URL points to the Sportarr API Episode
+    /// (Event).
     /// </summary>
     public class SportarrEpisodeExternalId : IExternalId
     {

--- a/agents/jellyfin/Sportarr/SportarrExternalIdProvider.cs
+++ b/agents/jellyfin/Sportarr/SportarrExternalIdProvider.cs
@@ -1,0 +1,83 @@
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace Jellyfin.Plugin.Sportarr
+{
+    /// <summary>
+    /// Registers the Sportarr provider ID as a known external identifier for series (leagues).
+    /// This surfaces the stored "Sportarr" provider ID (e.g. "lg-000028") as a labelled field
+    /// in the Jellyfin metadata editor, alongside IMDb/TheTVDB IDs.
+    /// </summary>
+    public class SportarrSeriesExternalId : IExternalId
+    {
+        /// <summary>
+        /// Gets the display label shown for this external ID in the metadata editor.
+        /// </summary>
+        public string ProviderName => "Sportarr";
+
+        /// <summary>
+        /// Gets the provider key. Must match the key used by SetProviderId("Sportarr", ...)
+        /// so the editor field binds to the stored value.
+        /// </summary>
+        public string Key => "Sportarr";
+
+        /// <summary>
+        /// Gets the media type this external ID applies to, so Jellyfin routes it to the
+        /// correct (series) metadata editor.
+        /// </summary>
+        public ExternalIdMediaType? Type => ExternalIdMediaType.Series;
+
+        /// <summary>
+        /// Gets the URL format string for linking out to the ID. The "{0}" placeholder is
+        /// replaced with the stored Sportarr ID to produce a clickable link.
+        /// </summary>
+        public string? UrlFormatString => "https://sportarr.net/api/metadata/agents/series/{0}";
+
+        /// <summary>
+        /// Determines whether this external ID applies to the given item.
+        /// </summary>
+        /// <param name="item">The item to test.</param>
+        /// <returns>True for <see cref="Series"/> items; otherwise false.</returns>
+        public bool Supports(IHasProviderIds item) => item is Series;
+    }
+
+    /// <summary>
+    /// Registers the Sportarr provider ID as a known external identifier for episodes
+    /// (matches/events). This surfaces the stored "Sportarr" provider ID as a labelled field
+    /// in the Jellyfin metadata editor, alongside IMDb/TheTVDB IDs.
+    /// </summary>
+    public class SportarrEpisodeExternalId : IExternalId
+    {
+        /// <summary>
+        /// Gets the display label shown for this external ID in the metadata editor.
+        /// </summary>
+        public string ProviderName => "Sportarr";
+
+        /// <summary>
+        /// Gets the provider key. Must match the key used by SetProviderId("Sportarr", ...)
+        /// so the editor field binds to the stored value.
+        /// </summary>
+        public string Key => "Sportarr";
+
+        /// <summary>
+        /// Gets the media type this external ID applies to, so Jellyfin routes it to the
+        /// correct (episode) metadata editor.
+        /// </summary>
+        public ExternalIdMediaType? Type => ExternalIdMediaType.Episode;
+
+        /// <summary>
+        /// Gets the URL format string for linking out to the ID. The "{0}" placeholder is
+        /// replaced with the stored Sportarr ID to produce a clickable link.
+        /// </summary>
+        public string? UrlFormatString => "https://sportarr.net/api/metadata/agents/episode/{0}";
+
+        /// <summary>
+        /// Determines whether this external ID applies to the given item.
+        /// </summary>
+        /// <param name="item">The item to test.</param>
+        /// <returns>True for <see cref="Episode"/> items; otherwise false.</returns>
+        public bool Supports(IHasProviderIds item) => item is Episode;
+    }
+}

--- a/agents/jellyfin/manifest.json
+++ b/agents/jellyfin/manifest.json
@@ -8,12 +8,12 @@
     "category": "Metadata",
     "versions": [
       {
-        "version": "4.0.1005.1084",
-        "changelog": "See https://github.com/Sportarr/Sportarr/releases/tag/v4.0.1005.1084",
+        "version": "4.0.1006.1085",
+        "changelog": "See https://github.com/Sportarr/Sportarr/releases/tag/v4.0.1006.1085",
         "targetAbi": "10.9.0.0",
-        "sourceUrl": "https://github.com/Sportarr/Sportarr/releases/download/v4.0.1005.1084/sportarr-jellyfin-plugin_4.0.1005.1084.zip",
-        "checksum": "1e90e6e0b934c3e40beb41eedf524c3e",
-        "timestamp": "2026-05-29T22:44:02Z"
+        "sourceUrl": "https://github.com/Sportarr/Sportarr/releases/download/v4.0.1006.1085/sportarr-jellyfin-plugin_4.0.1006.1085.zip",
+        "checksum": "8b9ece5cb0447bcaf0f2ab251be93b1b",
+        "timestamp": "2026-05-29T23:19:09Z"
       }
     ]
   }

--- a/src/Version.cs
+++ b/src/Version.cs
@@ -16,7 +16,7 @@ public static class Version
 {
     // Application version - base 3-part version (set manually)
     // Starting at 4.0.5 (migrated from 4.0.4.9 4-part versioning)
-    public const string AppVersion = "4.0.1005";
+    public const string AppVersion = "4.0.1006";
 
     // API version - stays at 1.0.0 for API stability
     public const string ApiVersion = "1.0.0";


### PR DESCRIPTION
This PR implements the IExternalID interface for both Jellyfin and Emby. This gives the user a visible representation of the actual object behind the metadata from the Sportarr API.

<img width="2528" height="1732" alt="image" src="https://github.com/user-attachments/assets/fe7d0ed3-1f27-49bc-a86f-6a41a2f5a63c" />

<img width="2000" height="1732" alt="image" src="https://github.com/user-attachments/assets/c06fe91b-218a-4730-a6b7-9c15ea7f4e2d" />

