### PR TITLE
fix: extract year from {Year}x{Round} release names

### DIFF
--- a/src/Services/ReleaseMatchingService.cs
+++ b/src/Services/ReleaseMatchingService.cs
@@ -113,6 +113,15 @@ public class ReleaseMatchingService
         new Regex(@"Round[\s\.\-]*(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),   // Round 22, Round22
         new Regex(@"\bRd[\s\.\-]*(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),    // Rd 22, Rd22
         new Regex(@"\bR(\d{1,2})\b", RegexOptions.Compiled | RegexOptions.IgnoreCase),        // R22 (not R2025)
+        // {Year}x{Round} marker (e.g. "2026x02" -> round 2): the round follows
+        // the season-year after an 'x'. Some feeds (Sky's F1 releases among
+        // them) carry no "Round" keyword, so without this the round-mismatch
+        // guard below never fires and a wrong-round release could ride the year
+        // bonus over threshold. Listed last so explicit Round/Rd/R forms win
+        // when both are present. The boundaries are [^0-9A-Za-z] lookarounds
+        // rather than \b so underscore-delimited titles (Formula_1_2026x02_...)
+        // match too -- '_' is a word char, so \b would not fire around it.
+        new Regex(@"(?<![0-9A-Za-z])20[12]\dx(\d{1,2})(?![0-9A-Za-z])", RegexOptions.Compiled | RegexOptions.IgnoreCase), // 2026x02
     };
 
     private static readonly Regex _splitSeparatorsRegex = new(

--- a/src/Services/SportsFileNameParser.cs
+++ b/src/Services/SportsFileNameParser.cs
@@ -470,6 +470,17 @@ public class SportsFileNameParser
     // and without pulling the year out, match confidence caps below the
     // threshold and RSS sync silently drops the release.
     private static readonly Regex SeasonEpisodeYearPattern = new(@"[Ss](?<year>20[12]\d)[Ee]\d+", RegexOptions.Compiled);
+    // {Year}x{Round} season marker where the season is the year and a round
+    // follows immediately after an 'x' (e.g. "2026x02" = 2026 season, round 2).
+    // Scene releases use it for round-based sports -- Sky's Formula 1 feed is
+    // one example (Formula.1.2026x02.China.Race.SkyF1HD.1080p). YearOnlyPattern
+    // misses it because the 'x' joining the year and round is a word character,
+    // so the \b after the year never fires -- the year stays unextracted, the
+    // year-match bonus is lost, and the release scores below the confidence
+    // threshold and gets dropped. Only the year is captured; the round digits
+    // are matched (to anchor the format) but intentionally not surfaced -- see
+    // the extraction site below.
+    private static readonly Regex SeasonRoundYearPattern = new(@"\b(?<year>20[12]\d)x\d{1,2}\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public SportsFileNameParser(ILogger<SportsFileNameParser> logger)
     {
@@ -609,8 +620,33 @@ public class SportsFileNameParser
                     }
                     else
                     {
-                        _logger.LogDebug("[SportsFileNameParser] No date/year found in '{Filename}' (cleanName: '{CleanName}')",
-                            filename, cleanName);
+                        // Fallback: {Year}x{Round} season marker (e.g.
+                        // "2026x02"). The 'x' joining the year and round is a
+                        // word character, so neither YearOnlyPattern nor the
+                        // SxxxxExx marker above can pull the year out. Surface
+                        // only the year -- that earns the year-match bonus and
+                        // lifts the release over the confidence threshold.
+                        //
+                        // The round is deliberately NOT written to RoundNumber
+                        // here. ReleaseMatchingService reads it straight off the
+                        // title for its round-mismatch guard, compared against
+                        // Event.Round. Surfacing it via SportsParseResult would
+                        // also feed LibraryImportService, which compares the
+                        // round against the cumulative Event.EpisodeNumber
+                        // (round 2 spans E10-E16 for motorsport) and would
+                        // wrongly penalise the correct event.
+                        var xYearMatch = SeasonRoundYearPattern.Match(cleanName);
+                        if (xYearMatch.Success && int.TryParse(xYearMatch.Groups["year"].Value, out var xYear))
+                        {
+                            result.EventYear = xYear;
+                            _logger.LogDebug("[SportsFileNameParser] Extracted year {Year} from YYYYxNN marker in '{Filename}'",
+                                xYear, filename);
+                        }
+                        else
+                        {
+                            _logger.LogDebug("[SportsFileNameParser] No date/year found in '{Filename}' (cleanName: '{CleanName}')",
+                                filename, cleanName);
+                        }
                     }
                 }
             }

--- a/tests/Sportarr.Api.Tests/Services/SportsFileNameParserTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/SportsFileNameParserTests.cs
@@ -1,0 +1,67 @@
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Year extraction coverage for the {Year}x{Round} naming format (e.g.
+/// "2026x02"), used by scene releases for round-based sports — Sky's Formula 1
+/// feed is one example (Formula.1.2026x02.China.Race.SkyF1HD.1080p). The 'x'
+/// joining the year and round is a word character, so the bare year regex never
+/// saw a word boundary after the year and left it unextracted — the release
+/// lost the year-match bonus and scored below the confidence threshold, so RSS
+/// sync silently dropped correct matches (issue #107). These tests pin the
+/// year/round extraction and guard the existing formats against regression.
+/// </summary>
+public class SportsFileNameParserTests
+{
+    private readonly SportsFileNameParser _parser = new(Mock.Of<ILogger<SportsFileNameParser>>());
+
+    [Theory]
+    // The exact Sky F1 releases from issue #107.
+    [InlineData("Formula.1.2026x02.China.Race.SkyF1UHD.4K-GROUP", 2026)]
+    [InlineData("Formula.1.2026x02.China.Race.SkyF1HD.1080p", 2026)]
+    [InlineData("Formula.1.2026x02.China.Qualifying.SkyF1UHD.4K-GROUP", 2026)]
+    [InlineData("Formula.1.2026x02.China.Qualifying.SkyF1HD.1080p", 2026)]
+    [InlineData("Formula.1.2026x02.China.Sprint.Race.SkyF1UHD.4K-GROUP", 2026)]
+    [InlineData("Formula.1.2026x02.China.Sprint.Qualifying.SkyF1HD.1080p", 2026)]
+    [InlineData("Formula.1.2026x01.Australia.Race.SkyF1HD.1080p", 2026)]
+    // Single-digit round and uppercase separator are handled too.
+    [InlineData("Formula.1.2025x9.Canada.Race.SkyF1HD.1080p", 2025)]
+    [InlineData("Formula.1.2024X05.Miami.Race.SkyF1HD.1080p", 2024)]
+    public void Parse_YearXRoundFormat_ExtractsYear(string filename, int expectedYear)
+    {
+        var result = _parser.Parse(filename);
+
+        result.EventYear.Should().Be(expectedYear);
+        // The round is deliberately NOT surfaced here — it's matched off the
+        // title in ReleaseMatchingService against Event.Round. Surfacing it
+        // would feed LibraryImportService's round-vs-EpisodeNumber check, which
+        // mis-penalises motorsport's cumulative episode numbering.
+        result.RoundNumber.Should().BeNull();
+    }
+
+    [Theory]
+    // Regression guard: the formats that already worked must keep extracting the year.
+    [InlineData("Formula1.2026.Round08.Monaco.Grand.Prix.1080p.WEB-GROUP", 2026)]
+    [InlineData("Formula.1.2026.Monaco.Grand.Prix.SkyF1HD.1080p", 2026)]
+    [InlineData("Formula1.S2026E34.Monaco.1080p.WEB.x264-GROUP", 2026)]
+    public void Parse_ExistingYearFormats_StillExtractYear(string filename, int expectedYear)
+    {
+        _parser.Parse(filename).EventYear.Should().Be(expectedYear);
+    }
+
+    [Theory]
+    // Resolution-like NNNNxNNNN tokens must not be misread as {Year}x{Round}:
+    // 1920/2560/3840 are not 20[12]x years, and 2026x1080p has a 4-digit second
+    // term that the 1-2 digit round (plus word boundary) deliberately rejects.
+    [InlineData("Some.Stream.1920x1080.h264-GROUP")]
+    [InlineData("Some.Stream.2560x1440.h264-GROUP")]
+    [InlineData("Formula.1.2026x1080p.China.Race-GROUP")]
+    public void Parse_ResolutionTokens_AreNotTreatedAsYear(string filename)
+    {
+        _parser.Parse(filename).EventYear.Should().BeNull();
+    }
+}

--- a/tests/Sportarr.Api.Tests/Services/YearRoundFormatMatchingTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/YearRoundFormatMatchingTests.cs
@@ -1,0 +1,101 @@
+using Sportarr.Api.Services;
+using Sportarr.Api.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// End-to-end matching coverage for issue #107: releases naming the season and
+/// round as a single {Year}x{Round} token (e.g. "Formula.1.2026x02.China.Race",
+/// as used by Sky's Formula 1 feed) left the year unextracted, so the release
+/// missed the year-match bonus and scored below MinimumMatchConfidence (60). Now
+/// that the year is pulled out, the release earns the year-match against the
+/// correct season and is correctly hard-rejected against the wrong season.
+/// </summary>
+public class YearRoundFormatMatchingTests
+{
+    private readonly ReleaseMatchingService _svc;
+
+    public YearRoundFormatMatchingTests()
+    {
+        var parser = new SportsFileNameParser(Mock.Of<ILogger<SportsFileNameParser>>());
+        var partDetector = new EventPartDetector(Mock.Of<ILogger<EventPartDetector>>());
+        _svc = new ReleaseMatchingService(Mock.Of<ILogger<ReleaseMatchingService>>(), parser, partDetector);
+    }
+
+    private static ReleaseSearchResult Rel(string title) => new()
+    {
+        Title = title,
+        Guid = title,
+        DownloadUrl = "http://test/" + title,
+        Indexer = "Test",
+    };
+
+    private static Event ChineseGrandPrix(int year, string? round = null) => new()
+    {
+        Id = 1,
+        Title = "Chinese Grand Prix",
+        Sport = "Motorsport",
+        EventDate = new DateTime(year, 3, 21, 7, 0, 0, DateTimeKind.Utc),
+        Round = round,
+        League = new League { Id = 1, Name = "Formula 1", Sport = "Motorsport" }
+    };
+
+    [Fact]
+    public void YearXRoundRelease_EarnsYearMatchAgainstCorrectSeason()
+    {
+        var result = _svc.ValidateRelease(
+            Rel("Formula.1.2026x02.China.Race.SkyF1HD.1080p"), ChineseGrandPrix(2026));
+
+        // The whole point of #107: the year is now extracted, so the release
+        // earns the year-match bonus instead of being silently dropped.
+        result.MatchReasons.Should().Contain("Year matches (2026)");
+        result.IsHardRejection.Should().BeFalse();
+        result.IsMatch.Should().BeTrue();
+        result.Confidence.Should().BeGreaterThanOrEqualTo(ReleaseMatchingService.MinimumMatchConfidence);
+    }
+
+    [Fact]
+    public void YearXRoundRelease_IsHardRejectedAgainstWrongSeason()
+    {
+        var result = _svc.ValidateRelease(
+            Rel("Formula.1.2026x02.China.Race.SkyF1HD.1080p"), ChineseGrandPrix(2025));
+
+        // A 2026 release must not match the 2025 Chinese Grand Prix.
+        result.IsHardRejection.Should().BeTrue();
+        result.IsMatch.Should().BeFalse();
+        result.Rejections.Should().Contain(r => r.Contains("Year mismatch"));
+    }
+
+    [Theory]
+    // The round embedded in "2026x02" must feed the round-mismatch guard,
+    // otherwise the year bonus alone could push a wrong-round release over the
+    // threshold for a same-year event. Round 02 != event Round 3. The second
+    // case uses underscores: '_' is a word character, so the matcher's round
+    // extraction has to treat it as a separator (not rely on \b).
+    [InlineData("Formula.1.2026x02.China.Race.SkyF1HD.1080p")]
+    [InlineData("Formula_1_2026x02_China_Race_SkyF1HD_1080p")]
+    public void YearXRoundRelease_RoundIsUsedForTheMismatchGuard(string title)
+    {
+        var result = _svc.ValidateRelease(Rel(title), ChineseGrandPrix(2026, round: "3"));
+
+        result.IsHardRejection.Should().BeTrue();
+        result.IsMatch.Should().BeFalse();
+        result.Rejections.Should().Contain(r => r.Contains("Round mismatch"));
+    }
+
+    [Fact]
+    public void YearXRoundRelease_MatchesWhenRoundAgrees()
+    {
+        // Same release against the matching round earns the round bonus on top
+        // of the year match.
+        var result = _svc.ValidateRelease(
+            Rel("Formula.1.2026x02.China.Race.SkyF1HD.1080p"), ChineseGrandPrix(2026, round: "2"));
+
+        result.MatchReasons.Should().Contain("Round number matches: Round 2");
+        result.IsHardRejection.Should().BeFalse();
+        result.IsMatch.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Fixes year parsing for releases that use the `{Year}x{Round}` naming format, like `Formula.1.2026x02.China.Race.SkyF1HD.1080p`. Ref #107.

These pack the season and round into one token (`2026x02` = 2026 season, round 2) instead of spelling out `Round 02`. The parser never pulled the year out of that shape, so the release missed the year-match bonus and landed at 55% confidence, just under the default 60% threshold, and RSS sync quietly dropped releases that were actually correct. Sky's F1 feed is where it turned up, but it's about the `{Year}x{Round}` shape rather than any one indexer.

The cause is the year regex (`\b20[12]\d\b`): it wants a word boundary right after the year, but the `x` glued onto it is a word character, so the boundary never fires. Same reason the year-only check already misses `S2026E34`.

What changed:

- Pull the year out of `{Year}x{Round}` in the parser's year-extraction chain so the release clears the threshold. Resolution-ish tokens like `1920x1080` / `2026x1080p` stay safe, since the round is capped at 1-2 digits with a separator boundary.
- Teach the matcher's round extraction the same shape so the round-mismatch guard works on titles with no "Round" keyword. `2026x02` is treated like `Round02` and compared against `Event.Round`, so a wrong-round release can't ride the year bonus over the line against a same-year event. Underscore-delimited titles work too.
- The round is matched off the title in `ReleaseMatchingService` rather than surfaced via the parser, so it never reaches the library importer's round-vs-EpisodeNumber check (motorsport episode numbers are cumulative, round 2 spans E10-E16).

Tests: parser tests for the formats from the issue plus regression and resolution-token guards, and end-to-end matching tests through `ReleaseMatchingService`. Full suite green (361 tests).
