### PR TITLE
fix(jellyfin): bump plugin targetAbi from 10.9.0.0 to 10.10.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
             'versions': [{
               'version': '${VERSION}',
               'changelog': 'See https://github.com/${REPO}/releases/tag/${TAG}',
-              'targetAbi': '10.9.0.0',
+              'targetAbi': '10.10.0.0',
               'sourceUrl': 'https://github.com/${REPO}/releases/download/${TAG}/sportarr-jellyfin-plugin_${VERSION}.zip',
               'checksum': '${CHECKSUM}',
               'timestamp': '${TIMESTAMP}'

--- a/agents/jellyfin/Sportarr/meta.json
+++ b/agents/jellyfin/Sportarr/meta.json
@@ -7,7 +7,7 @@
   "overview": "Automatically enriches your sports library with metadata from Sportarr including event descriptions, air dates, posters, banners, and thumbnails.",
   "owner": "Sportarr",
   "status": "Active",
-  "targetAbi": "10.9.0.0",
+  "targetAbi": "10.10.0.0",
   "timestamp": "",
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Problem

The Jellyfin plugin currently advertises `targetAbi: 10.9.0.0` in both:
- `agents/jellyfin/Sportarr/meta.json` — bundled into the release zip
- `.github/workflows/release.yml` (line 340) — regenerates `agents/jellyfin/manifest.json` on every release

Jellyfin 10.9 went EOL in August 2024. The current stable lines (10.10 LTS and 10.11) both reject the plugin at load time with:

```
[ERR] Error creating "Jellyfin.Plugin.Sportarr.SportarrPlugin"
[ERR] Error while starting server
```

So anyone installing via the Sportarr repository on a supported Jellyfin version sees a startup failure with no metadata flowing.

## Fix

Bump the `targetAbi` string to `10.10.0.0` in both files. CI will then regenerate `manifest.json` with the corrected value on the next release.

## Verification

Locally on Jellyfin 10.11.11 (latest stable, 2026-06-06):

1. Installed `v4.0.1010.1090` from a downloaded release zip
2. Manually edited `meta.json`'s `targetAbi` to `10.10.0.0`
3. Restarted Jellyfin — plugin loads cleanly:
   ```
   [INF] Loaded assembly Jellyfin.Plugin.Sportarr, Version=4.0.1010.1090
   [INF] Loaded plugin: Sportarr 4.0.1010.1090
   ```
4. Configured the plugin to point at a local Sportarr instance (`http://localhost:1867`-equivalent)
5. Added a UFC test file (`UFC/Season 2026/UFC - S2026E01 - test - 720p.mkv`), rescanned the library
6. Plugin's `SportarrSeriesProvider` / `EpisodeProvider` / `ImageProvider` all fire correctly:
   ```
   [INF] [Sportarr] Updated episode: S2026E1 - UFC 324: Gaethje vs Pimblett
   ```
   Real fight card metadata, poster and event title resolved from Sportarr-Hub end-to-end.

The plugin's API surface (`BasePlugin`, `IRemoteSearchProvider`, `IRemoteImageProvider`, `IHttpClientFactory`, `IDirectoryService`) is stable from Jellyfin 10.9 through 10.11 — no rebuild is required, only the ABI declaration needs to reflect reality.

## Scope

This PR **only** touches the two `targetAbi` strings. The `Jellyfin.Controller` / `Jellyfin.Model` NuGet refs in `Sportarr.csproj` are left at `10.9.*` so the produced binary is byte-identical to current. Happy to follow up with a separate PR bumping those refs to `10.10.*` (the more "honest" build) if you'd prefer that direction.

## Side note

Line 311 of `release.yml` already carries the comment *"include meta.json for Jellyfin 10.11+ plugin discovery"*, so 10.10+ support is clearly intended — the 10.9 ABI string in the same workflow looks like an oversight that's been carried forward through every release commit.