### PR TITLE
Decryptarr usenet client fixed, follows current api setup

### DIFF
--- a/src/Services/DownloadClientService.cs
+++ b/src/Services/DownloadClientService.cs
@@ -284,7 +284,7 @@ public class DownloadClientService : IDownloadClientService
                 DownloadClientType.Sabnzbd => WrapLegacyResult(await AddToSabnzbdAsync(config, url, category)),
                 DownloadClientType.NzbGet => WrapLegacyResult(await AddToNzbGetAsync(config, url, category)),
                 DownloadClientType.Decypharr => await AddToDecypharrWithResultAsync(config, url, category, expectedName, seedRatioLimit, seedTimeLimitMinutes),
-                DownloadClientType.DecypharrUsenet => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category)), // Decypharr usenet uses SABnzbd API emulation - must use URL mode so Decypharr can intercept
+                DownloadClientType.DecypharrUsenet => WrapLegacyResult(await AddToDecypharrUsenetAsync(config, url, category)), // Decypharr usenet only supports addfile mode (not addurl) and requires a specific request format. See https://docs.decypharr.com/guides/usenet/sabnzbd/
                 DownloadClientType.NZBdav => WrapLegacyResult(await AddToSabnzbdViaUrlAsync(config, url, category)), // NZBdav uses SABnzbd API but only supports addurl mode (not addfile)
                 _ => AddDownloadResult.Failed($"Download client type {config.Type} not supported", AddDownloadErrorType.Unknown)
             };
@@ -716,6 +716,19 @@ public class DownloadClientService : IDownloadClientService
         var client = GetSabnzbdClient(config);
         var nzoId = await client.AddNzbViaUrlOnlyAsync(config, url, category);
         return nzoId;
+    }
+
+    /// <summary>
+    /// Add NZB to DecypharrUsenet using its specific SABnzbd-compatible API format.
+    /// Decypharr only supports addfile mode (not addurl) and requires:
+    ///   - mode=addfile in the query string (not form data)
+    ///   - File field name "name" (not "nzbfile")
+    /// See: https://docs.decypharr.com/guides/usenet/sabnzbd/
+    /// </summary>
+    private async Task<string?> AddToDecypharrUsenetAsync(DownloadClient config, string url, string category)
+    {
+        var client = GetSabnzbdClient(config);
+        return await client.AddNzbForDecypharrAsync(config, url, category);
     }
 
     private async Task<string?> AddToNzbGetAsync(DownloadClient config, string url, string category)

--- a/src/Services/SabnzbdClient.cs
+++ b/src/Services/SabnzbdClient.cs
@@ -213,6 +213,103 @@ public class SabnzbdClient
     }
 
     /// <summary>
+    /// Add NZB to DecypharrUsenet - which only supports addfile mode with a specific format.
+    /// Decypharr's SABnzbd API emulator requires:
+    ///   - POST to /sabnzbd/api?mode=addfile&output=json (mode in QUERY STRING, not form data)
+    ///   - File field name "name" (not "nzbfile")
+    ///   - No API key required (Decypharr ignores it)
+    /// See: https://docs.decypharr.com/guides/usenet/sabnzbd/
+    /// This method is intentionally separate from AddNzbAsync/AddNzbViaContentAsync so the
+    /// normal SABnzbd routing remains unchanged.
+    /// </summary>
+    public async Task<string?> AddNzbForDecypharrAsync(DownloadClient config, string nzbUrl, string category)
+    {
+        try
+        {
+            _logger.LogInformation("[DecypharrUsenet] Fetching NZB from: {Url}", nzbUrl);
+
+            // Fetch the NZB file as raw bytes to preserve encoding
+            using var response = await _httpClient.GetAsync(nzbUrl);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("[DecypharrUsenet] Failed to fetch NZB: HTTP {StatusCode}", response.StatusCode);
+                return null;
+            }
+
+            var nzbBytes = await response.Content.ReadAsByteArrayAsync();
+            var filename = GetNzbFilename(response, nzbUrl);
+
+            _logger.LogInformation("[DecypharrUsenet] Downloaded NZB: {Filename} ({Size} bytes)", filename, nzbBytes.Length);
+
+            // Validate the NZB content before uploading
+            var validationResult = ValidateNzbContent(nzbBytes);
+            if (!validationResult.IsValid)
+            {
+                _logger.LogError("[DecypharrUsenet] Invalid NZB content: {Reason}. Content preview: {Preview}",
+                    validationResult.Reason, validationResult.ContentPreview);
+                return null;
+            }
+
+            // Build base URL (same path handling as standard SABnzbd)
+            var protocol = config.UseSsl ? "https" : "http";
+            var urlBase = config.UrlBase ?? "";
+            if (!string.IsNullOrEmpty(urlBase))
+            {
+                if (!urlBase.StartsWith("/")) urlBase = "/" + urlBase;
+                urlBase = urlBase.TrimEnd('/');
+            }
+            var baseUrl = $"{protocol}://{config.Host}:{config.Port}{urlBase}/api";
+
+            // Decypharr requires mode and output in the QUERY STRING (not form data).
+            // Sending them in form data causes Decypharr to return a default 404 page.
+            var uploadUrl = $"{baseUrl}?mode=addfile&output=json";
+
+            // Build multipart content. Decypharr requires the file field to be named "name"
+            // (the SABnzbd standard). Using "nzbfile" causes Decypharr to return
+            // {"status":false,"error":"No files uploaded"}.
+            using var content = new MultipartFormDataContent();
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                content.Add(new StringContent(category), "cat");
+            }
+
+            var fileContent = new ByteArrayContent(nzbBytes);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-nzb");
+            content.Add(fileContent, "name", filename);
+
+            _logger.LogInformation("[DecypharrUsenet] Uploading NZB to: {Url}", uploadUrl);
+
+            using var uploadResponse = await _httpClient.PostAsync(uploadUrl, content);
+            var responseContent = await uploadResponse.Content.ReadAsStringAsync();
+
+            _logger.LogDebug("[DecypharrUsenet] Upload response: {Status} {Body}",
+                uploadResponse.StatusCode, responseContent);
+
+            if (uploadResponse.IsSuccessStatusCode && !string.IsNullOrEmpty(responseContent))
+            {
+                var doc = JsonDocument.Parse(responseContent);
+                if (doc.RootElement.TryGetProperty("nzo_ids", out var ids) &&
+                    ids.GetArrayLength() > 0)
+                {
+                    var nzoId = ids[0].GetString();
+                    _logger.LogInformation("[DecypharrUsenet] NZB added successfully: {NzoId}", nzoId);
+                    return nzoId;
+                }
+            }
+
+            _logger.LogError("[DecypharrUsenet] Failed to add NZB: {Status} - {Response}",
+                uploadResponse.StatusCode, responseContent);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[DecypharrUsenet] Error adding NZB");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Extract filename from response headers or URL
     /// </summary>
     private string GetNzbFilename(HttpResponseMessage response, string url)


### PR DESCRIPTION
The decryptarr download client was using URL mode for the usenet implementation, but this is no longer valid. The current version ony has the addfile endpoint.
See also: https://docs.decypharr.com/guides/usenet/sabnzbd/