### PR TITLE
fix: Resolve baseUrl routing for reverse proxy subpath deployments

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
-import { Toaster } from 'sonner';
+import { useState, useEffect, useRef } from 'react';
+import { Toaster, toast } from 'sonner';
 import Layout from './components/Layout';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthProvider } from './contexts/AuthContext';
@@ -47,6 +47,7 @@ import DvrSchedulePage from './pages/iptv/DvrSchedulePage';
 import TvGuidePage from './pages/iptv/TvGuidePage';
 import WatchChannelPage from './pages/iptv/WatchChannelPage';
 import IptvCoveragePage from './pages/iptv/IptvCoveragePage';
+import { API_CONTRACT_FAILURE_EVENT, type ApiContractFailureDetail } from './utils/apiContract';
 
 // Hook to cleanup orphaned inert attributes from Headless UI modals
 // This is a failsafe - the primary cleanup happens in modal afterLeave callbacks
@@ -114,6 +115,32 @@ const queryClient = new QueryClient({
 function App() {
   // Global cleanup for orphaned inert attributes from Headless UI modals
   useInertCleanup();
+  const lastApiContractToastRef = useRef<{ key: string; timestamp: number } | null>(null);
+
+  useEffect(() => {
+    const onApiContractFailure = (event: Event) => {
+      const customEvent = event as CustomEvent<ApiContractFailureDetail>;
+      const detail = customEvent.detail;
+      const toastKey = `${detail.method}:${detail.url}:${detail.status}`;
+      const now = Date.now();
+      const lastToast = lastApiContractToastRef.current;
+
+      if (lastToast && lastToast.key === toastKey && now - lastToast.timestamp < 5000) {
+        return;
+      }
+
+      lastApiContractToastRef.current = { key: toastKey, timestamp: now };
+
+      toast.error('API routing/configuration error', {
+        description: `${detail.message} (${detail.method} ${detail.url})`,
+      });
+    };
+
+    window.addEventListener(API_CONTRACT_FAILURE_EVENT, onApiContractFailure as EventListener);
+    return () => {
+      window.removeEventListener(API_CONTRACT_FAILURE_EVENT, onApiContractFailure as EventListener);
+    };
+  }, []);
 
   return (
     <ErrorBoundary>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { emitApiContractFailure, isHtmlResponseContentType, htmlResponseMessage } from '../utils/apiContract';
+import { createRequestUrl } from '../utils/request';
 
 // Get API configuration from window.Sportarr (set by backend)
 declare global {
@@ -23,12 +25,138 @@ const apiClient = axios.create({
   },
 });
 
-// Add API key to all requests
-apiClient.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined' && window.Sportarr?.apiKey) {
-    config.headers['X-Api-Key'] = window.Sportarr.apiKey;
+const API_KEY_PRIME_ERROR_MESSAGE = 'Failed to fetch API key from initialize endpoint after authentication.';
+
+let apiKeyPrimePromise: Promise<string> | null = null;
+
+async function fetchApiKeyFromInitialize(): Promise<string> {
+  const initializeUrl = createRequestUrl('/initialize.json');
+  const response = await fetch(initializeUrl, {
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  const contentType = response.headers.get('content-type') || '';
+  if (isHtmlResponseContentType(contentType)) {
+    const message = htmlResponseMessage(response.status);
+    emitApiContractFailure({
+      url: initializeUrl,
+      method: 'GET',
+      status: response.status,
+      contentType,
+      message,
+    });
+    throw new Error(message);
   }
+
+  if (!response.ok) {
+    throw new Error(`${API_KEY_PRIME_ERROR_MESSAGE} (${response.status})`);
+  }
+
+  const data = await response.json();
+  const apiKey = String(data?.apiKey || '');
+
+  if (typeof window !== 'undefined') {
+    window.Sportarr = {
+      ...(window.Sportarr || { apiRoot: '', apiKey: '', urlBase: '', version: 'unknown' }),
+      ...data,
+      apiKey,
+    };
+  }
+
+  return apiKey;
+}
+
+async function ensureApiKey(): Promise<string> {
+  const existingKey = typeof window !== 'undefined' ? (window.Sportarr?.apiKey || '') : '';
+  if (existingKey) {
+    return existingKey;
+  }
+
+  if (!apiKeyPrimePromise) {
+    apiKeyPrimePromise = fetchApiKeyFromInitialize().finally(() => {
+      apiKeyPrimePromise = null;
+    });
+  }
+
+  return apiKeyPrimePromise;
+}
+
+export async function primeApiKey(): Promise<void> {
+  await ensureApiKey();
+}
+
+export function clearPrimedApiKey(): void {
+  apiKeyPrimePromise = null;
+  if (typeof window !== 'undefined' && window.Sportarr) {
+    window.Sportarr.apiKey = '';
+  }
+}
+
+// Add API key to all requests
+apiClient.interceptors.request.use(async (config) => {
+  const apiKey = await ensureApiKey();
+  if (apiKey) {
+    config.headers['X-Api-Key'] = apiKey;
+  }
+
+  if (!config.headers.Accept) {
+    config.headers.Accept = 'application/json';
+  }
+
   return config;
 });
+
+apiClient.interceptors.response.use(
+  (response) => {
+    const contentType = String(response.headers['content-type'] || '');
+    const isHtml = isHtmlResponseContentType(contentType);
+    const isProblemJson404 = contentType.toLowerCase().includes('application/problem+json') && response.status === 404;
+
+    if (!isHtml && !isProblemJson404) {
+      return response;
+    }
+
+    const message = isHtml
+      ? htmlResponseMessage(response.status)
+      : 'API endpoint was not found. Verify UrlBase and reverse proxy rewrite rules.';
+
+    emitApiContractFailure({
+      url: String(response.config?.url || ''),
+      method: String(response.config?.method || 'get').toUpperCase(),
+      status: response.status,
+      contentType,
+      message,
+    });
+
+    return Promise.reject(new Error(message));
+  },
+  (error) => {
+    const contentType = String(error?.response?.headers?.['content-type'] || '');
+    const isHtml = isHtmlResponseContentType(contentType);
+    const isProblemJson404 = contentType.toLowerCase().includes('application/problem+json')
+      && Number(error?.response?.status || 0) === 404;
+
+    if (isHtml || isProblemJson404) {
+      const errorStatus = Number(error?.response?.status || 0);
+      const errorMessage = isHtml
+        ? htmlResponseMessage(errorStatus)
+        : 'API endpoint was not found. Verify UrlBase and reverse proxy rewrite rules.';
+
+      emitApiContractFailure({
+        url: String(error?.config?.url || ''),
+        method: String(error?.config?.method || 'get').toUpperCase(),
+        status: errorStatus,
+        contentType,
+        message: errorMessage,
+      });
+      error.message = errorMessage;
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import type { ReactNode } from 'react';
 import { HomeIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
+import { getImageUrl } from '../utils/request';
 
 interface Props {
   children: ReactNode;
@@ -58,7 +59,7 @@ export class ErrorBoundary extends Component<Props, State> {
   };
 
   handleGoHome = () => {
-    window.location.href = '/leagues';
+    window.location.assign(window.Sportarr?.urlBase ? `${window.Sportarr.urlBase}/leagues` : '/leagues');
   };
 
   render() {
@@ -69,7 +70,7 @@ export class ErrorBoundary extends Component<Props, State> {
             {/* Error Image */}
             <div className="mb-8">
               <img
-                src="/error.png"
+                src={getImageUrl('error.png')}
                 alt="Error"
                 className="w-full max-w-md mx-auto"
               />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useSystemStatus, useActivityCounts } from '../api/hooks';
+import { getImageUrl } from '../utils/request';
 import {
   FolderIcon,
   ClockIcon,
@@ -193,7 +194,7 @@ export default function Layout() {
         <div className="flex items-center justify-between p-3">
           <Link to="/leagues" onClick={() => { cleanupInertAttributes(); setMobileMenuOpen(false); }} className="flex items-center space-x-2">
             <img
-              src="/logo-64.png"
+              src={getImageUrl('logo-64.png')}
               alt="Sportarr Logo"
               className="w-8 h-8 rounded-lg"
             />
@@ -233,7 +234,7 @@ export default function Layout() {
         <div className="hidden md:block p-4 border-b border-red-900/30">
           <Link to="/leagues" onClick={cleanupInertAttributes} className="flex items-center space-x-3">
             <img
-              src="/logo-64.png"
+              src={getImageUrl('logo-64.png')}
               alt="Sportarr Logo"
               className="w-10 h-10 rounded-lg"
             />

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { createRequestUrl } from '../utils/request';
+import { primeApiKey, clearPrimedApiKey } from '../api/client';
 
 interface AuthState {
   isAuthenticated: boolean;
@@ -25,6 +27,19 @@ const initialAuthState: AuthState = {
   isLoading: true,
 };
 
+function normalizeAppPath(path: string): string {
+  const urlBase = window.Sportarr?.urlBase || '';
+  if (!path) {
+    return '/leagues';
+  }
+
+  if (urlBase && path.startsWith(urlBase + '/')) {
+    return path.slice(urlBase.length) || '/';
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   // Use a single state object to ensure atomic updates and prevent flash
   const [authState, setAuthState] = useState<AuthState>(initialAuthState);
@@ -41,13 +56,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
-      const response = await fetch('/api/auth/check', {
+      const response = await fetch(createRequestUrl('/api/auth/check'), {
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
 
-      // Use window.location.pathname to get the actual browser URL
-      const currentPath = window.location.pathname;
+      // Extract relative path by removing UrlBase prefix (window.location.pathname includes it)
+      // This ensures /login comparison works correctly when deployed at any subpath
+      const urlBase = window.Sportarr?.urlBase || '';
+      const currentPath = window.location.pathname.startsWith(urlBase)
+        ? window.location.pathname.slice(urlBase.length) || '/'
+        : window.location.pathname;
       console.log('[AUTH] Current path:', currentPath);
 
       if (response.ok) {
@@ -72,7 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // This is the ONLY navigation we do - ProtectedRoute handles redirects TO login
         if (authenticated && currentPath === '/login') {
           const searchParams = new URLSearchParams(window.location.search);
-          const returnUrl = searchParams.get('returnUrl') || '/leagues';
+          const returnUrl = normalizeAppPath(searchParams.get('returnUrl') || '/leagues');
           console.log('[AUTH] Already authenticated on login page, redirecting to:', returnUrl);
           navigate(returnUrl, { replace: true });
         }
@@ -125,7 +144,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = async (username: string, password: string, rememberMe: boolean): Promise<boolean> => {
     try {
-      const response = await fetch('/api/login', {
+      const response = await fetch(createRequestUrl('/api/login'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -136,6 +155,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (response.ok) {
         const data = await response.json();
         if (data.success) {
+          // Prime API key immediately after login to avoid first-page 401 race
+          // before a hard reload or auth re-check updates in-memory window.Sportarr.
+          await primeApiKey();
           setAuthState(prev => ({ ...prev, isAuthenticated: true }));
           return true;
         }
@@ -149,10 +171,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = async () => {
     try {
-      await fetch('/api/logout', { method: 'POST', credentials: 'include' });
+      await fetch(createRequestUrl('/api/logout'), { method: 'POST', credentials: 'include' });
     } catch (error) {
       console.error('Logout failed:', error);
     } finally {
+      clearPrimedApiKey();
       setAuthState(prev => ({ ...prev, isAuthenticated: false }));
       navigate('/login');
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { createRequestUrl } from './utils/request';
 
 // Initialize window.Sportarr from backend
 async function init() {
   try {
-    const initializeUrl = `${window.Sportarr?.urlBase || ''}/initialize.json?t=${Date.now()}`;
+    const initializeUrl = createRequestUrl('/initialize.json') + `?t=${Date.now()}`;
     const response = await fetch(initializeUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch initialize.json: ${response.status}`);

--- a/frontend/src/pages/BackupPage.tsx
+++ b/frontend/src/pages/BackupPage.tsx
@@ -10,6 +10,7 @@ import {
 import PageHeader from '../components/PageHeader';
 import PageShell from '../components/PageShell';
 import { apiGet, apiPost, apiDelete } from '../utils/api';
+import { createRequestUrl, getImageUrl } from '../utils/request';
 import { parseAsUtc } from '../utils/timezone';
 
 interface BackupInfo {
@@ -259,7 +260,7 @@ const BackupPage: React.FC = () => {
     try {
       const form = new FormData();
       form.append('backup', file);
-      const response = await fetch('/api/system/backup/upload', {
+      const response = await fetch(createRequestUrl('/api/system/backup/upload'), {
         method: 'POST',
         body: form,
       });

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useRouteError, isRouteErrorResponse } from 'react-router-dom';
 import { HomeIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { getImageUrl } from '../utils/request';
 
 export default function ErrorPage() {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ export default function ErrorPage() {
         {/* Error Image */}
         <div className="mb-8">
           <img
-            src="/error.png"
+            src={getImageUrl('error.png')}
             alt="Error"
             className="w-full max-w-md mx-auto"
           />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,19 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { LockClosedIcon } from '@heroicons/react/24/outline';
 import { useAuth } from '../contexts/AuthContext';
 
+function normalizeAppPath(path: string): string {
+  const urlBase = window.Sportarr?.urlBase || '';
+  if (!path) {
+    return '/leagues';
+  }
+
+  if (urlBase && path.startsWith(urlBase + '/')) {
+    return path.slice(urlBase.length) || '/';
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
 export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -22,8 +35,8 @@ export default function LoginPage() {
     try {
       const success = await login(username, password, rememberMe);
       if (success) {
-        // Login successful, redirect to return URL or events
-        window.location.href = returnUrl;
+        // Login successful, redirect with router-aware path so basename/urlBase is preserved.
+        navigate(normalizeAppPath(returnUrl), { replace: true });
       } else {
         setError('Invalid username or password');
       }

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { HomeIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { getImageUrl } from '../utils/request';
 
 export default function NotFoundPage() {
   const navigate = useNavigate();
@@ -10,7 +11,7 @@ export default function NotFoundPage() {
         {/* 404 Image */}
         <div className="mb-8">
           <img
-            src="/404.png"
+            src={getImageUrl('404.png')}
             alt="404 - Page Not Found"
             className="w-full max-w-md mx-auto"
           />

--- a/frontend/src/pages/SystemEventsPage.tsx
+++ b/frontend/src/pages/SystemEventsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import { TrashIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
 import PageHeader from '../components/PageHeader';
@@ -125,7 +126,7 @@ const SystemEventsPage: React.FC = () => {
           <InformationCircleIcon className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" />
           <div className="text-sm text-gray-300">
             <strong className="text-white">System Events:</strong> This page shows an audit trail of system operations.
-            For detailed application logs, visit the <a href="/system/logs" className="text-blue-400 hover:underline">Log Files</a> page.
+            For detailed application logs, visit the <Link to="/system/logs" className="text-blue-400 hover:underline">Log Files</Link> page.
           </div>
         </div>
       </div>

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,31 @@
 // API utility for making authenticated requests to Sportarr backend
 
-let cachedApiKey: string | null = null;
+import { createRequestUrl } from './request';
+import { emitApiContractFailure, isHtmlResponseContentType, htmlResponseMessage } from './apiContract';
+
+function ensureApiJsonContract(response: Response, method: string, url: string): void {
+  const contentType = response.headers.get('content-type');
+  const isHtml = isHtmlResponseContentType(contentType);
+  const isProblemJson = !!contentType && contentType.toLowerCase().includes('application/problem+json');
+
+  if (!isHtml && !(isProblemJson && response.status === 404)) {
+    return;
+  }
+
+  const message = isHtml
+    ? htmlResponseMessage(response.status)
+    : 'API endpoint was not found. Verify UrlBase and reverse proxy rewrite rules.';
+
+  emitApiContractFailure({
+    url,
+    method,
+    status: response.status,
+    contentType: contentType || 'unknown',
+    message,
+  });
+
+  throw new Error(message);
+}
 
 /**
  * Fetch the API key from the initialize endpoint
@@ -11,7 +36,11 @@ export async function getApiKey(): Promise<string> {
   }
 
   try {
-    const response = await fetch('/initialize.json');
+    const initializeUrl = createRequestUrl('/initialize.json');
+    const response = await fetch(initializeUrl, {
+      headers: { Accept: 'application/json' },
+    });
+    ensureApiJsonContract(response, 'GET', initializeUrl);
     if (!response.ok) {
       throw new Error('Failed to fetch initialize data');
     }
@@ -27,20 +56,30 @@ export async function getApiKey(): Promise<string> {
   }
 }
 
+let cachedApiKey: string | null = null;
+
 /**
  * Make an authenticated API request with the API key header
  */
 export async function apiRequest(url: string, options: RequestInit = {}): Promise<Response> {
   const apiKey = await getApiKey();
+  const method = options.method ?? 'GET';
 
   const headers = new Headers(options.headers);
   headers.set('X-Api-Key', apiKey);
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json');
+  }
 
-  return fetch(url, {
+  const fullUrl = createRequestUrl(url);
+  const response = await fetch(fullUrl, {
     ...options,
     headers,
     credentials: 'include',
   });
+
+  ensureApiJsonContract(response, method, fullUrl);
+  return response;
 }
 
 /**

--- a/frontend/src/utils/apiContract.ts
+++ b/frontend/src/utils/apiContract.ts
@@ -1,0 +1,42 @@
+export const API_CONTRACT_FAILURE_EVENT = 'sportarr:api-contract-failure';
+
+export interface ApiContractFailureDetail {
+  url: string;
+  method: string;
+  status: number;
+  contentType: string;
+  message: string;
+}
+
+export function emitApiContractFailure(detail: ApiContractFailureDetail): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent<ApiContractFailureDetail>(API_CONTRACT_FAILURE_EVENT, { detail }));
+}
+
+export function isHtmlResponseContentType(contentType: string | null | undefined): boolean {
+  return !!contentType && contentType.toLowerCase().includes('text/html');
+}
+
+/**
+ * Classify an HTML API response into a user-facing message based on HTTP status.
+ *
+ * 5xx  → server-side error (HTML error page from the app or a gateway)
+ * 4xx  → proxy/routing issued its own HTML error page instead of the app's JSON
+ * 2xx  → SPA index.html served instead of JSON (classic UrlBase misconfiguration)
+ * other → generic unexpected HTML
+ */
+export function htmlResponseMessage(status: number): string {
+  if (status >= 500) {
+    return `Server error (HTTP ${status}). Check the Sportarr server logs for details.`;
+  }
+  if (status >= 400) {
+    return `Proxy or gateway returned an HTML error page (HTTP ${status}). Verify reverse proxy configuration.`;
+  }
+  if (status >= 200 && status < 300) {
+    return 'The server returned an HTML page instead of JSON. Check UrlBase and reverse proxy path rewriting.';
+  }
+  return `Unexpected HTML response (HTTP ${status}).`;
+}

--- a/frontend/src/utils/request.test.ts
+++ b/frontend/src/utils/request.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequestUrl, getImageUrl } from './request';
+
+describe('Request URL Builder (UrlBase Support)', () => {
+  let originalWindow: any;
+
+  beforeEach(() => {
+    // Store original window.Sportarr
+    originalWindow = (window as any).Sportarr;
+  });
+
+  afterEach(() => {
+    // Restore original window.Sportarr
+    if (originalWindow) {
+      (window as any).Sportarr = originalWindow;
+    } else {
+      delete (window as any).Sportarr;
+    }
+  });
+
+  describe('createRequestUrl', () => {
+    it('should return path as-is when UrlBase is empty', () => {
+      (window as any).Sportarr = { urlBase: '' };
+      expect(createRequestUrl('/api/leagues')).toBe('/api/leagues');
+      expect(createRequestUrl('/initialize.json')).toBe('/initialize.json');
+    });
+
+    it('should prepend UrlBase when configured', () => {
+      (window as any).Sportarr = { urlBase: '/sportarr' };
+      expect(createRequestUrl('/api/leagues')).toBe('/sportarr/api/leagues');
+      expect(createRequestUrl('/initialize.json')).toBe('/sportarr/initialize.json');
+    });
+
+    it('should handle paths without leading slash', () => {
+      (window as any).Sportarr = { urlBase: '/my-subpath' };
+      expect(createRequestUrl('api/test')).toBe('/my-subpath/api/test');
+      expect(createRequestUrl('logo.png')).toBe('/my-subpath/logo.png');
+    });
+
+    it('should gracefully handle missing window.Sportarr', () => {
+      delete (window as any).Sportarr;
+      expect(createRequestUrl('/api/leagues')).toBe('/api/leagues');
+    });
+
+    it('should work with complex paths', () => {
+      (window as any).Sportarr = { urlBase: '/sportarr' };
+      expect(createRequestUrl('/api/system/backup/upload')).toBe('/sportarr/api/system/backup/upload');
+      expect(createRequestUrl('/api/leagues/123')).toBe('/sportarr/api/leagues/123');
+    });
+  });
+
+  describe('getImageUrl', () => {
+    it('should prepend / and UrlBase for image filenames', () => {
+      (window as any).Sportarr = { urlBase: '/sportarr' };
+      expect(getImageUrl('logo-64.png')).toBe('/sportarr/logo-64.png');
+      expect(getImageUrl('error.png')).toBe('/sportarr/error.png');
+      expect(getImageUrl('404.png')).toBe('/sportarr/404.png');
+    });
+
+    it('should return root path for images when UrlBase is empty', () => {
+      (window as any).Sportarr = { urlBase: '' };
+      expect(getImageUrl('logo-64.png')).toBe('/logo-64.png');
+    });
+
+    it('should handle missing window.Sportarr', () => {
+      delete (window as any).Sportarr;
+      expect(getImageUrl('error.png')).toBe('/error.png');
+    });
+  });
+});

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -1,0 +1,47 @@
+/**
+ * Unified request URL builder for reverse proxy subpath support.
+ * 
+ * Constructs full request URLs using window.Sportarr.urlBase (set by backend),
+ * ensuring all API calls and assets are routed correctly when deployed behind
+ * a reverse proxy at a subpath (e.g., /sportarr).
+ * 
+ * Usage:
+ *   fetch(createRequestUrl('/api/auth/check'))
+ *   <img src={getImageUrl('logo-64.png')} />
+ */
+
+/**
+ * Create a full request URL with UrlBase prefix if configured.
+ * 
+ * @param path - The request path (e.g., '/api/auth/check', 'initialize.json', '/logo-64.png')
+ * @returns Full URL with UrlBase prefix (e.g., '/sportarr/api/auth/check')
+ * 
+ * @example
+ *   createRequestUrl('/api/leagues') // Without UrlBase: '/api/leagues'
+ *   createRequestUrl('/api/leagues') // With UrlBase='/sportarr': '/sportarr/api/leagues'
+ */
+export function createRequestUrl(path: string): string {
+  // Normalize path to always start with /
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  
+  // Get UrlBase from window.Sportarr (set by backend before React loads)
+  // Defaults to empty string if not set (graceful degradation to root path)
+  const urlBase = typeof window !== 'undefined' ? (window.Sportarr?.urlBase || '') : '';
+  
+  return `${urlBase}${normalizedPath}`;
+}
+
+/**
+ * Create a full URL for image assets with UrlBase prefix if configured.
+ * Semantic wrapper around createRequestUrl for clarity when dealing with assets.
+ * 
+ * @param filename - The image filename (e.g., 'logo-64.png', 'error.png')
+ * @returns Full URL to the image (e.g., '/sportarr/logo-64.png')
+ * 
+ * @example
+ *   getImageUrl('logo-64.png') // Without UrlBase: '/logo-64.png'
+ *   getImageUrl('error.png')   // With UrlBase='/sportarr': '/sportarr/error.png'
+ */
+export function getImageUrl(filename: string): string {
+  return createRequestUrl(`/${filename}`);
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -539,23 +539,37 @@ app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks
     }
 });
 
+// Explicit routing endpoint selection before SPA middleware.
+// This ensures API endpoints are matched to handlers before the SPA fallback
+// middleware runs, preventing API routes from being served index.html.
+app.UseRouting();
+
 // Configure static files (UI from wwwroot)
 // For URL base support, we need to inject the urlBase into index.html
 // and rewrite asset paths to include the base
 app.Use(async (context, next) =>
 {
-    // Serve index.html with urlBase injection for SPA routes
     var path = context.Request.Path.Value ?? "";
+    var normalizedPath = NormalizePathForUrlBase(path, configuredUrlBase);
+    var endpoint = context.GetEndpoint();
+
+    // Debug: log SPA middleware path classification
+    if (path.StartsWith("/api", StringComparison.OrdinalIgnoreCase) ||
+        path.StartsWith("/sportarr", StringComparison.OrdinalIgnoreCase))
+    {
+        Log.Debug("[SPA MIDDLEWARE] Path={Path}, Normalized={Normalized}, PathBase={PathBase}, UrlBase={UrlBase}, EndpointMatched={HasEndpoint}, Endpoint={Endpoint}",
+            path, normalizedPath, context.Request.PathBase.Value, configuredUrlBase, endpoint != null, endpoint?.DisplayName);
+    }
 
     // Check if this is a request that should serve index.html (SPA fallback)
     // Skip API routes, static assets, and other special endpoints
-    var isApiOrAsset = path.StartsWith("/api", StringComparison.OrdinalIgnoreCase) ||
-                       path.StartsWith("/assets", StringComparison.OrdinalIgnoreCase) ||
-                       path.StartsWith("/initialize.json", StringComparison.OrdinalIgnoreCase) ||
-                       path.StartsWith("/ping", StringComparison.OrdinalIgnoreCase) ||
-                       path.StartsWith("/health", StringComparison.OrdinalIgnoreCase) ||
-                       path.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase) ||
-                       path.Contains(".");  // Has file extension (e.g., .js, .css, .svg)
+    var isApiOrAsset = normalizedPath.StartsWith("/api", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.StartsWith("/assets", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.StartsWith("/initialize.json", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.StartsWith("/ping", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.StartsWith("/health", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.StartsWith("/swagger", StringComparison.OrdinalIgnoreCase) ||
+                       normalizedPath.Contains(".");  // Has file extension (e.g., .js, .css, .svg)
 
     if (!isApiOrAsset)
     {
@@ -624,6 +638,45 @@ app.Use(async (context, next) =>
 
 app.UseDefaultFiles();
 app.UseStaticFiles();
+
+// Defensive API contract: ensure unmatched API requests return JSON payloads
+// rather than HTML fallback pages.
+app.UseStatusCodePages(async statusCodeContext =>
+{
+    var context = statusCodeContext.HttpContext;
+    if (context.Response.StatusCode != StatusCodes.Status404NotFound)
+    {
+        return;
+    }
+
+    var path = context.Request.Path.Value ?? "";
+    var normalizedPath = NormalizePathForUrlBase(path, configuredUrlBase);
+    if (!normalizedPath.StartsWith("/api", StringComparison.OrdinalIgnoreCase))
+    {
+        return;
+    }
+
+    context.Response.ContentType = "application/problem+json";
+    var problem = new
+    {
+        type = "https://tools.ietf.org/html/rfc9110#section-15.5.5",
+        title = "API endpoint not found",
+        status = StatusCodes.Status404NotFound,
+        detail = "The requested API endpoint was not found. Verify UrlBase/reverse-proxy path rewriting and request URL construction.",
+        instance = path,
+        traceId = context.TraceIdentifier,
+        pathBase = context.Request.PathBase.Value,
+        method = context.Request.Method
+    };
+
+    Log.Warning("[API ROUTING] Unmatched API request. Method={Method}, Path={Path}, PathBase={PathBase}, TraceId={TraceId}",
+        context.Request.Method,
+        context.Request.Path.Value,
+        context.Request.PathBase.Value,
+        context.TraceIdentifier);
+
+    await context.Response.WriteAsJsonAsync(problem);
+});
 
 // Initialize endpoint (for frontend) - keep for SPA compatibility
 app.MapGet("/initialize.json", async (HttpContext httpContext, Sportarr.Api.Services.ConfigService configService, SportarrDbContext db) =>
@@ -710,6 +763,26 @@ static async Task<bool> ShouldExposeApiKeyAsync(HttpContext context, SportarrDbC
     }
 
     return false;
+}
+
+static string NormalizePathForUrlBase(string path, string configuredUrlBase)
+{
+    if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(configuredUrlBase))
+    {
+        return path;
+    }
+
+    if (path.StartsWith(configuredUrlBase + "/", StringComparison.OrdinalIgnoreCase))
+    {
+        return path.Substring(configuredUrlBase.Length);
+    }
+
+    if (string.Equals(path, configuredUrlBase, StringComparison.OrdinalIgnoreCase))
+    {
+        return "/";
+    }
+
+    return path;
 }
 
 // Health check


### PR DESCRIPTION
Fixes hardcoded fetch requests that failed when Sportarr is served from a subpath (e.g., /sportarr). All client-side requests now correctly prepend the configured urlBase prefix.

Changes:
- Add request URL builder utilities for consistent urlBase handling
- Add defensive API contract validation with HTML response detection
- Update all fetch/axios calls to use createRequestUrl()
- Add deduped toast notifications for API routing errors
- Add server-side path normalization middleware
- Add UseStatusCodePages for JSON API error responses
- Comprehensive unit tests for URL building edge cases