### PR TITLE
Fix RSS re-grab loop re-downloading the same release every cycle (#175)

### DIFF
--- a/src/Services/GrabHistoryChurnGuard.cs
+++ b/src/Services/GrabHistoryChurnGuard.cs
@@ -1,0 +1,67 @@
+using Sportarr.Api.Models;
+
+namespace Sportarr.Api.Services;
+
+/// <summary>
+/// Anti-churn policy for automatic (RSS) re-fetching of a release that has already been
+/// grabbed for an event (issue #175).
+///
+/// <para>
+/// Background: <c>RssSyncService.GrabReleaseAsync</c> marks every prior grab for the same
+/// (EventId, PartName) as <see cref="GrabHistory.Superseded"/> whenever a competing release
+/// is grabbed. The old dedup filtered on <c>!Superseded</c>, so when two releases existed for
+/// one still-missing event (e.g. the same session posted by two indexers), each grab
+/// superseded the other's history row and the dedup memory was erased — the two releases
+/// ping-ponged and re-fetched the same <c>.nzb</c> from the indexer on every RSS cycle,
+/// the duplicate-download loop that gets indexer accounts flagged.
+/// </para>
+///
+/// <para>
+/// The caller now matches the most recent prior grab of the SAME release (by InfoHash, then
+/// Guid, then DownloadUrl) regardless of Superseded, and asks this guard whether re-fetching
+/// is permitted. The decision is a pure function of the prior grab's state so it is unit
+/// tested without a DbContext.
+/// </para>
+/// </summary>
+public static class GrabHistoryChurnGuard
+{
+    /// <summary>Hours a specific release is held back after a grab that has not imported.</summary>
+    public const int RegrabCooldownHours = 6;
+
+    /// <summary>Maximum automatic re-fetches of the same un-imported release before it is blocked outright.</summary>
+    public const int MaxAutomaticRegrabs = 3;
+
+    public enum Decision
+    {
+        /// <summary>No relevant prior grab (or it imported successfully) — let normal flow decide.</summary>
+        Allow,
+        /// <summary>Same release was grabbed too recently and has not imported — skip this cycle.</summary>
+        BlockCooldown,
+        /// <summary>Same release has been re-fetched the maximum number of times without importing — stop.</summary>
+        BlockCapReached,
+        /// <summary>Cooldown elapsed and under the cap — permit one controlled retry (caller records it).</summary>
+        AllowControlledRetry,
+    }
+
+    /// <summary>
+    /// Decide whether an automatic re-fetch of the release represented by <paramref name="priorGrab"/>
+    /// should proceed. <paramref name="nowUtc"/> is injected so the policy is deterministic in tests.
+    /// </summary>
+    public static Decision Evaluate(GrabHistory? priorGrab, DateTime nowUtc)
+    {
+        // No prior grab, or it already imported: this is not churn. A successful import is
+        // governed downstream by the existing-file score gate; a quality upgrade arrives as
+        // a different release (different Guid) and so never matches a prior grab here.
+        if (priorGrab is null || priorGrab.WasImported)
+            return Decision.Allow;
+
+        if (priorGrab.RegrabCount >= MaxAutomaticRegrabs)
+            return Decision.BlockCapReached;
+
+        var lastAttempt = priorGrab.LastRegrabAttempt ?? priorGrab.GrabbedAt;
+        if (nowUtc - lastAttempt < TimeSpan.FromHours(RegrabCooldownHours))
+            return Decision.BlockCooldown;
+
+        return Decision.AllowControlledRetry;
+    }
+}

--- a/src/Services/RssSyncService.cs
+++ b/src/Services/RssSyncService.cs
@@ -525,27 +525,75 @@ public class RssSyncService : BackgroundService
         if (isBlocklisted)
             return (false, "Blocklisted", releasePart);
 
-        // 3b. Check GrabHistory - prevent re-grabbing the same release.
-        bool alreadyGrabbed = false;
-
+        // 3b. Anti-churn guard (issue #175): never re-fetch the SAME release from an
+        // indexer in a tight loop. Match the most recent prior grab by InfoHash/Guid
+        // REGARDLESS of Superseded. RecordGrab() marks every prior same-event+part grab
+        // Superseded whenever a competing release is grabbed, so the old `&& !g.Superseded`
+        // filter let two releases for one missing event ping-pong and re-grab on every RSS
+        // cycle (the duplicate-download loop indexers flag). "Superseded" means the file
+        // was replaced — it must NOT erase the memory that we already fetched this URL.
+        GrabHistory? priorGrab = null;
         if (!string.IsNullOrEmpty(release.TorrentInfoHash))
         {
-            alreadyGrabbed = await db.GrabHistory
-                .AnyAsync(g => g.EventId == evt.Id
-                            && g.TorrentInfoHash == release.TorrentInfoHash
-                            && !g.Superseded, cancellationToken);
+            priorGrab = await db.GrabHistory
+                .Where(g => g.EventId == evt.Id && g.TorrentInfoHash == release.TorrentInfoHash)
+                .OrderByDescending(g => g.LastRegrabAttempt ?? g.GrabbedAt)
+                .FirstOrDefaultAsync(cancellationToken);
         }
-
-        if (!alreadyGrabbed && !string.IsNullOrEmpty(release.Guid))
+        if (priorGrab == null && !string.IsNullOrEmpty(release.Guid))
         {
-            alreadyGrabbed = await db.GrabHistory
-                .AnyAsync(g => g.EventId == evt.Id
-                            && g.Guid == release.Guid
-                            && !g.Superseded, cancellationToken);
+            priorGrab = await db.GrabHistory
+                .Where(g => g.EventId == evt.Id && g.Guid == release.Guid)
+                .OrderByDescending(g => g.LastRegrabAttempt ?? g.GrabbedAt)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+        // Usenet newznab feeds sometimes omit <guid> (NewznabClient leaves Guid=""), and
+        // Usenet releases carry no InfoHash — so neither key above can dedup them. Fall back
+        // to the actual fetch URL, which is always present and uniquely identifies the exact
+        // .nzb we would otherwise re-download from the indexer.
+        if (priorGrab == null && !string.IsNullOrEmpty(release.DownloadUrl))
+        {
+            priorGrab = await db.GrabHistory
+                .Where(g => g.EventId == evt.Id && g.DownloadUrl == release.DownloadUrl)
+                .OrderByDescending(g => g.LastRegrabAttempt ?? g.GrabbedAt)
+                .FirstOrDefaultAsync(cancellationToken);
         }
 
-        if (alreadyGrabbed)
-            return (false, "Already grabbed (in grab history)", releasePart);
+        // Decide whether re-fetching this exact release is churn. The decision is a pure
+        // function of the prior grab's state (imported?, attempt count, last-attempt age),
+        // extracted to GrabHistoryChurnGuard so it can be unit-tested without a DbContext.
+        // A successful prior import (Decision.Allow) defers to the existing-file score gate
+        // below; a genuine quality upgrade arrives as a DIFFERENT release so never lands here.
+        if (priorGrab != null)
+        {
+            var now = DateTime.UtcNow;
+            switch (GrabHistoryChurnGuard.Evaluate(priorGrab, now))
+            {
+                case GrabHistoryChurnGuard.Decision.BlockCapReached:
+                    return (false,
+                        $"Anti-churn: already grabbed this release {priorGrab.RegrabCount}x without a successful import — not re-fetching (blocklist it or fix the event match)",
+                        releasePart);
+
+                case GrabHistoryChurnGuard.Decision.BlockCooldown:
+                    var sinceLast = now - (priorGrab.LastRegrabAttempt ?? priorGrab.GrabbedAt);
+                    return (false,
+                        $"Anti-churn: grabbed this exact release {sinceLast.TotalMinutes:F0}m ago, within the {GrabHistoryChurnGuard.RegrabCooldownHours}h cooldown",
+                        releasePart);
+
+                case GrabHistoryChurnGuard.Decision.AllowControlledRetry:
+                    // Cooldown elapsed and under the cap: allow ONE controlled retry,
+                    // recording it so the cooldown and cap advance for next time.
+                    priorGrab.RegrabCount += 1;
+                    priorGrab.LastRegrabAttempt = now;
+                    await db.SaveChangesAsync(cancellationToken);
+                    _logger.LogInformation(
+                        "[RSS Sync] Controlled re-grab {Count}/{Max} of '{Title}' for event {EventId} after {Cooldown}h cooldown",
+                        priorGrab.RegrabCount, GrabHistoryChurnGuard.MaxAutomaticRegrabs, release.Title, evt.Id, GrabHistoryChurnGuard.RegrabCooldownHours);
+                    break;
+
+                // Decision.Allow: prior grab imported (or none) — fall through to normal flow.
+            }
+        }
 
         // 4. Check for recent failed downloads with backoff (part-aware)
         var recentFailedDownload = await db.DownloadQueue

--- a/src/Services/SportsFileNameParser.cs
+++ b/src/Services/SportsFileNameParser.cs
@@ -747,9 +747,12 @@ public class SportsFileNameParser
 
         // Order matters: check more specific patterns first
         // Practice (most specific first — bare "practice" falls through to Practice 1)
-        if (Regex.IsMatch(lower, @"\bpractice\s*3\b|\bfp3\b")) return "Practice 3";
-        if (Regex.IsMatch(lower, @"\bpractice\s*2\b|\bfp2\b")) return "Practice 2";
-        if (Regex.IsMatch(lower, @"\bpractice\s*1\b|\bfp1\b")) return "Practice 1";
+        // Accept word ordinals too ("Practice Three") so the import-side label matches the
+        // EventPartDetector match gate, which already handles (3|three). Without this a
+        // word-form release parses to "Practice 1" here and is mis-imported. (issue #136/#168)
+        if (Regex.IsMatch(lower, @"\bpractice\s*(3|three)\b|\bfp3\b")) return "Practice 3";
+        if (Regex.IsMatch(lower, @"\bpractice\s*(2|two)\b|\bfp2\b")) return "Practice 2";
+        if (Regex.IsMatch(lower, @"\bpractice\s*(1|one)\b|\bfp1\b")) return "Practice 1";
         if (Regex.IsMatch(lower, @"\bpractice\b|\bfree\s+practice\b")) return "Practice 1";
         // Sprint sessions
         if (Regex.IsMatch(lower, @"\bsprint\s+qualifying\b")) return "Sprint Qualifying";

--- a/tests/Sportarr.Api.Tests/Services/AustrianGpPracticeThreeTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/AustrianGpPracticeThreeTests.cs
@@ -1,0 +1,41 @@
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Regression for the 2026 Austrian GP duplicate-download incident: word-ordinal sessions
+/// ("Practice Three") must resolve to "Practice 3", not collapse to "Practice 1". When they
+/// don't, the release fails to match its event, the event stays missing, and it is re-grabbed
+/// every RSS cycle. The match gate (EventPartDetector) already handled this; the import-side
+/// parser (SportsFileNameParser) did not — both are pinned here.
+/// </summary>
+public class AustrianGpPracticeThreeTests
+{
+    private const string P3Billie = "Formula1.2026.Austrian.Grand.Prix.Practice.Three.1080p.WEB.h264-BILLIE";
+    private const string P3Darksport = "Formula1.2026.Austrian.Grand.Prix.Practice.Three.1080p.AHDTV.x264-DARKSPORT";
+
+    [Theory]
+    [InlineData(P3Billie, "Practice 3")]
+    [InlineData(P3Darksport, "Practice 3")]
+    [InlineData("Formula1.2026.Austrian.Grand.Prix.Practice.Two.1080p.WEB.h264-BILLIE", "Practice 2")]
+    [InlineData("Formula1.2026.Austrian.Grand.Prix.Practice.One.1080p.WEB.h264-BILLIE", "Practice 1")]
+    public void MatchGate_DetectsWordOrdinalSession(string filename, string expected)
+    {
+        EventPartDetector.DetectMotorsportSessionFromFilename(filename)
+            .Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(P3Billie, "Practice 3")]
+    [InlineData("Formula1.2026.Austrian.Grand.Prix.Practice.Two.1080p.WEB.h264-BILLIE", "Practice 2")]
+    [InlineData("Formula1.2026.Austrian.Grand.Prix.Practice.One.1080p.WEB.h264-BILLIE", "Practice 1")]
+    public void ImportParser_DetectsWordOrdinalSession(string filename, string expected)
+    {
+        var parser = new SportsFileNameParser(Mock.Of<ILogger<SportsFileNameParser>>());
+        parser.Parse(filename).Session.Should().Be(expected);
+    }
+}

--- a/tests/Sportarr.Api.Tests/Services/GrabHistoryChurnGuardTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/GrabHistoryChurnGuardTests.cs
@@ -1,0 +1,70 @@
+using System;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Anti-churn guard (issue #175). Reproduces the duplicate-download loop: two releases for
+/// one still-missing event each supersede the other's GrabHistory row, so the old
+/// <c>!Superseded</c> dedup let them ping-pong and re-fetch the same .nzb every RSS cycle.
+/// The guard bounds re-fetching of the SAME un-imported release by a cooldown and a hard cap.
+/// </summary>
+public class GrabHistoryChurnGuardTests
+{
+    private static readonly DateTime Now = new(2026, 6, 28, 12, 30, 0, DateTimeKind.Utc);
+
+    private static GrabHistory Grab(
+        int regrabCount = 0,
+        bool wasImported = false,
+        DateTime? grabbedAt = null,
+        DateTime? lastRegrab = null) => new()
+    {
+        Title = "Formula1.2026.Austrian.Grand.Prix.Practice.Three.1080p.WEB.h264-BILLIE",
+        Indexer = "NZBfinder",
+        DownloadUrl = "https://example.invalid/getnzb?id=abc.nzb",
+        Guid = "abc",
+        Protocol = "Usenet",
+        GrabbedAt = grabbedAt ?? Now.AddMinutes(-5),
+        LastRegrabAttempt = lastRegrab,
+        RegrabCount = regrabCount,
+        WasImported = wasImported,
+    };
+
+    [Fact]
+    public void NullPriorGrab_Allows()
+        => GrabHistoryChurnGuard.Evaluate(null, Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.Allow);
+
+    [Fact]
+    public void ImportedPriorGrab_Allows_NotChurn()
+        => GrabHistoryChurnGuard.Evaluate(Grab(wasImported: true, grabbedAt: Now.AddMinutes(-1)), Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.Allow);
+
+    [Fact]
+    public void RecentUnimportedGrab_BlocksOnCooldown()
+        => GrabHistoryChurnGuard.Evaluate(Grab(grabbedAt: Now.AddMinutes(-5)), Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.BlockCooldown);
+
+    [Fact]
+    public void AfterCooldown_UnderCap_AllowsControlledRetry()
+        => GrabHistoryChurnGuard.Evaluate(Grab(grabbedAt: Now.AddHours(-(GrabHistoryChurnGuard.RegrabCooldownHours + 1))), Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.AllowControlledRetry);
+
+    [Fact]
+    public void AtCap_BlocksRegardlessOfAge()
+        => GrabHistoryChurnGuard.Evaluate(
+                Grab(regrabCount: GrabHistoryChurnGuard.MaxAutomaticRegrabs, grabbedAt: Now.AddDays(-30)), Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.BlockCapReached);
+
+    [Fact]
+    public void LastRegrabAttempt_TakesPrecedenceOverGrabbedAt()
+    {
+        // Originally grabbed two days ago, but a retry was logged 10 minutes ago: still cooling down.
+        var g = Grab(regrabCount: 1, grabbedAt: Now.AddDays(-2), lastRegrab: Now.AddMinutes(-10));
+        GrabHistoryChurnGuard.Evaluate(g, Now)
+            .Should().Be(GrabHistoryChurnGuard.Decision.BlockCooldown);
+    }
+}


### PR DESCRIPTION
## Problem

On the RSS path, Sportarr can re-fetch the **same release `.nzb` from an indexer on every sync cycle** for a single still-missing event. With two competing releases for one event (e.g. the same session posted by two indexers), they alternate indefinitely — dozens of duplicate indexer downloads per day. At least one Usenet indexer flags this as abusive duplicate downloading and threatens account termination. This is the mechanism behind #175.

## Root cause

`RssSyncService.GrabReleaseAsync` marks **every** prior grab for the same `(EventId, PartName)` as `Superseded` whenever a competing release is grabbed:

```csharp
var previousGrabs = await db.GrabHistory
    .Where(g => g.EventId == evt.Id && g.PartName == partName && !g.Superseded)
    .ToListAsync(ct);
foreach (var oldGrab in previousGrabs) oldGrab.Superseded = true;
```

…but the dedup precheck in `ShouldGrabReleaseAsync` filtered on `!g.Superseded`:

```csharp
alreadyGrabbed = await db.GrabHistory.AnyAsync(g =>
    g.EventId == evt.Id && g.Guid == release.Guid && !g.Superseded, ct);
```

So release **A** is grabbed → row A inserted. Release **B** (different indexer/Guid, same missing event) is grabbed → row A flipped to `Superseded`. Next cycle, A re-appears in the feed; the dedup only sees non-superseded rows, A's row is now superseded, so **A is grabbed again** — which supersedes B — and they ping-pong forever. `Superseded` is meant to express "the file was replaced", but here it erases the memory that the URL was already fetched.

A secondary gap: Usenet newznab items with no `<guid>` get `Guid = ""` (`NewznabClient.cs`), and Usenet has no `TorrentInfoHash`, so **neither** dedup key fires and such releases were never deduped at all.

## Fix

- **Dedup regardless of `Superseded`.** Match the most recent prior grab by `TorrentInfoHash` → `Guid` → **`DownloadUrl`** (new fallback, always present, covers the empty-`Guid` Usenet case), independent of the superseded flag.
- **Bounded re-fetch policy**, extracted to a pure, unit-tested `GrabHistoryChurnGuard`: an *un-imported* release may be re-fetched at most once per **6 h cooldown** up to a hard cap of **3 attempts** (advancing the existing-but-previously-unused `RegrabCount` / `LastRegrabAttempt` fields), then it is blocked outright. Successful imports defer to the existing-file score gate, and genuine quality upgrades arrive as a *different* release (different Guid) so they are never throttled here.
- **Session word-ordinal parsing.** `SportsFileNameParser.DetectMotorsportSession` now accepts word ordinals (`Practice Three` → `Practice 3`), matching `EventPartDetector` so the import-side session label agrees with the match gate instead of collapsing word-form sessions to `Practice 1` (relates to the F1 session-matching reports #103 / #117 / #136 / #168).

## Tests

- `GrabHistoryChurnGuardTests` — cooldown, cap, imported/null, and `LastRegrabAttempt` precedence.
- `AustrianGpPracticeThreeTests` — the exact releases from the incident, asserted against **both** the match gate (`EventPartDetector`) and the import parser (`SportsFileNameParser`).
- Full suite green.

## Verification

Built from this branch and deployed to a live instance that had been looping on the 2026 Austrian GP Practice 3. After deploy: each session is grabbed exactly once, no release is re-fetched for the same event across cycles, and the previously-stuck Practice 3 now matches and downloads. `NRestarts=0`, no unhandled exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
