### PR TITLE
Drop orphaned RemoveCompletedDownloads/RemoveFailedDownloads columns (fixes NOT NULL crash on settings save + import)

### DIFF
--- a/src/Migrations/20260617000000_DropOrphanedRemoveDownloadColumns.cs
+++ b/src/Migrations/20260617000000_DropOrphanedRemoveDownloadColumns.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sportarr.Api.Migrations
+{
+    /// <summary>
+    /// Drops the orphaned RemoveCompletedDownloads / RemoveFailedDownloads columns
+    /// from MediaManagementSettings.
+    ///
+    /// These settings were moved to per-download-client configuration (see the
+    /// MediaManagementSettings model — the properties were removed and replaced with
+    /// a "now per-client" note), and the model snapshot was updated to match. But no
+    /// migration ever dropped the underlying columns. On databases created before the
+    /// move, the two columns linger as NOT NULL with no default. Because EF's INSERT
+    /// no longer includes them (the entity stopped mapping them), saving Media
+    /// Management settings — and the import pipeline's GetMediaManagementSettingsAsync
+    /// get-or-create — fails with:
+    ///
+    ///   SQLite Error 19: 'NOT NULL constraint failed: MediaManagementSettings.RemoveCompletedDownloads'
+    ///
+    /// which blocks both the Settings page save and completed-download imports.
+    ///
+    /// The actual drop is performed by the raw-SQL safety net in DatabaseInitializer
+    /// (guarded by pragma_table_info checks), matching how recent schema changes are
+    /// applied in this project; this migration documents the change.
+    /// </summary>
+    public partial class DropOrphanedRemoveDownloadColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RemoveCompletedDownloads",
+                table: "MediaManagementSettings");
+
+            migrationBuilder.DropColumn(
+                name: "RemoveFailedDownloads",
+                table: "MediaManagementSettings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RemoveCompletedDownloads",
+                table: "MediaManagementSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RemoveFailedDownloads",
+                table: "MediaManagementSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/Startup/DatabaseInitializer.cs
+++ b/src/Startup/DatabaseInitializer.cs
@@ -975,6 +975,35 @@ public static class DatabaseInitializer
             Console.WriteLine($"[Sportarr] Warning: Could not remove legacy MediaManagementSettings.RootFolders column: {ex.Message}");
         }
 
+        // Drop the orphaned MediaManagementSettings.RemoveCompletedDownloads /
+        // RemoveFailedDownloads columns. These settings moved to per-download-client
+        // configuration (the MediaManagementSettings model no longer maps them), but
+        // no migration dropped the columns. On databases created before the move they
+        // linger as NOT NULL with no default, and because EF's INSERT no longer
+        // includes them, saving Media Management settings and the import pipeline's
+        // GetMediaManagementSettingsAsync get-or-create both fail with
+        // "SQLite Error 19: NOT NULL constraint failed: MediaManagementSettings.RemoveCompletedDownloads".
+        // Requires SQLite 3.35+ (DROP COLUMN); the bundled Microsoft.Data.Sqlite satisfies that.
+        foreach (var legacyCol in new[] { "RemoveCompletedDownloads", "RemoveFailedDownloads" })
+        {
+            try
+            {
+                var checkLegacyCol = $"SELECT COUNT(*) FROM pragma_table_info('MediaManagementSettings') WHERE name='{legacyCol}'";
+                var legacyColExists = db.Database.SqlQueryRaw<int>(checkLegacyCol).AsEnumerable().FirstOrDefault();
+
+                if (legacyColExists > 0)
+                {
+                    Console.WriteLine($"[Sportarr] Removing orphaned MediaManagementSettings.{legacyCol} column (now a per-download-client setting)...");
+                    db.Database.ExecuteSqlRaw($@"ALTER TABLE ""MediaManagementSettings"" DROP COLUMN ""{legacyCol}""");
+                    Console.WriteLine($"[Sportarr] MediaManagementSettings.{legacyCol} column removed");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Sportarr] Warning: Could not remove orphaned MediaManagementSettings.{legacyCol} column: {ex.Message}");
+            }
+        }
+
         // Ensure Events.BroadcastDate column exists.
         // The seeding code above marks every migration in the assembly as
         // applied for legacy EnsureCreated() databases - including newer


### PR DESCRIPTION
## Problem

On a pre-existing database, saving **Media Management** settings or importing a completed download fails with:

```
SQLite Error 19: 'NOT NULL constraint failed: MediaManagementSettings.RemoveCompletedDownloads'
   at Sportarr.Api.Services.FileImportService.GetMediaManagementSettingsAsync()
   at Sportarr.Api.Services.FileImportService.ImportDownloadAsync(...)
   at Sportarr.Api.Services.EnhancedDownloadMonitorService.HandleCompletedDownload(...)
PUT /api/settings -> 500
```

This breaks **both** the Settings page (`PUT /api/settings`) and the **completed-download import pipeline** — the importer's get-or-create of the `MediaManagementSettings` row throws, so downloads finish but never import.

## Root cause

`RemoveCompletedDownloads` and `RemoveFailedDownloads` were moved to per-download-client settings: `src/Models/Settings.cs` no longer maps them (there's a *"now per-client"* note) and `SportarrDbContextModelSnapshot.cs` was updated to match. **But no migration ever dropped the underlying columns.** On databases created before that change, the two columns linger as `NOT NULL` with no default. Because EF's generated `INSERT` no longer includes them, the insert violates the constraint.

## Fix

Mirrors the existing `DropMediaManagementRootFoldersColumn` change (same table, same mechanism):

1. **`DatabaseInitializer`** — a `pragma_table_info`-guarded raw-SQL safety net that `DROP COLUMN`s each column only if present. This matches how recent schema changes are actually applied in this project. Requires SQLite 3.35+ (`DROP COLUMN`), which the bundled `Microsoft.Data.Sqlite` satisfies.
2. **Documentation migration** `20260617000000_DropOrphanedRemoveDownloadColumns` recording the change, with a reversible `Down`.

No snapshot change is needed — `SportarrDbContextModelSnapshot.cs` already omits these columns.

## Testing

Reproduced on a pre-existing `4.0.1012`/`4.0.1013` SQLite database with the orphaned columns present: confirmed the `NOT NULL` failure on both `PUT /api/settings` and completed-download import. The pragma-guarded `ALTER TABLE "MediaManagementSettings" DROP COLUMN ...` clears both columns and resolves both failures; the equivalent SQL was validated directly against a live DB before wiring it into the standard `DatabaseInitializer` path. The drop is idempotent (guarded by the existence check) and a no-op on fresh DBs that never had the columns.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
