### PR TITLE
Fix Deluge failing on magnet-redirect releases

### DIFF
--- a/src/Services/DelugeClient.cs
+++ b/src/Services/DelugeClient.cs
@@ -112,13 +112,49 @@ public class DelugeClient
     }
 
     /// <summary>
-    /// Add torrent from URL.
-    /// NOTE: Does NOT specify download_location - Deluge uses its own configured directory.
-    ///
-    /// Uses core.add_torrent_file instead of core.add_torrent_url to avoid SSL/HTTPS issues
-    /// with Prowlarr proxy URLs. Downloads the torrent file first, then sends as base64.
+    /// Add a torrent from already-downloaded .torrent file bytes via core.add_torrent_file.
+    /// The caller (DownloadClientService) resolves the indexer/proxy URL first through
+    /// TorrentFileResolver so magnet redirects and malformed URLs are handled before we
+    /// reach Deluge — Deluge's own add_torrent_url can't follow a cross-scheme magnet
+    /// redirect and fails with "Unsupported scheme".
+    /// NOTE: Does NOT specify download_location unless config.Directory is set - otherwise
+    /// Deluge uses its own configured directory.
     /// </summary>
-    public async Task<string?> AddTorrentAsync(DownloadClient config, string torrentUrl, string category, double? seedRatioLimit = null, int? seedTimeLimitMinutes = null)
+    public async Task<string?> AddTorrentFromBytesAsync(DownloadClient config, byte[] torrentBytes, string category, double? seedRatioLimit = null, int? seedTimeLimitMinutes = null)
+    {
+        _logger.LogDebug("[Deluge] Adding torrent file to Deluge via add_torrent_file ({Bytes} bytes)", torrentBytes.Length);
+        var base64Content = Convert.ToBase64String(torrentBytes);
+        return await AddTorrentInternalAsync(config, "core.add_torrent_file",
+            options => new object[] { "download.torrent", base64Content, options },
+            category, seedRatioLimit, seedTimeLimitMinutes);
+    }
+
+    /// <summary>
+    /// Add a torrent from a magnet link via core.add_torrent_magnet. Used for magnet-only
+    /// indexers (and HTTP links that redirect to a magnet), which Deluge's add_torrent_url
+    /// path cannot handle.
+    /// </summary>
+    public async Task<string?> AddTorrentMagnetAsync(DownloadClient config, string magnetUrl, string category, double? seedRatioLimit = null, int? seedTimeLimitMinutes = null)
+    {
+        _logger.LogInformation("[Deluge] Adding magnet to Deluge via add_torrent_magnet");
+        return await AddTorrentInternalAsync(config, "core.add_torrent_magnet",
+            options => new object[] { magnetUrl, options },
+            category, seedRatioLimit, seedTimeLimitMinutes);
+    }
+
+    /// <summary>
+    /// Shared add-torrent flow: logs in, builds the common Deluge options
+    /// (add_paused / download_location), issues the RPC built by
+    /// <paramref name="buildParams"/>, then applies label, seed limits and the
+    /// configured initial state to the returned hash.
+    /// </summary>
+    private async Task<string?> AddTorrentInternalAsync(
+        DownloadClient config,
+        string method,
+        Func<Dictionary<string, object>, object[]> buildParams,
+        string category,
+        double? seedRatioLimit,
+        int? seedTimeLimitMinutes)
     {
         try
         {
@@ -130,7 +166,7 @@ public class DelugeClient
                 return null;
             }
 
-            // Build Deluge options (shared between add_torrent_file and add_torrent_url)
+            // Build Deluge options (shared between add_torrent_file and add_torrent_magnet)
             var shouldPause = config.InitialState == TorrentInitialState.Stopped;
             if (shouldPause)
             {
@@ -147,40 +183,7 @@ public class DelugeClient
                 _logger.LogInformation("[Deluge] Using directory override: {Directory}", config.Directory);
             }
 
-            // Try to download the torrent file first and send as base64 (preferred - avoids
-            // Deluge's SSL/HTTPS issues with Prowlarr proxy URLs). If the download fails
-            // (e.g. redirect to a URL with an unparseable hostname from certain indexers),
-            // fall back to core.add_torrent_url and let Deluge handle the download itself.
-            _logger.LogDebug("[Deluge] Downloading torrent file from URL: {Url}", torrentUrl);
-
-            string? response;
-            byte[]? torrentBytes = null;
-            try
-            {
-                var httpClient = GetHttpClient(config);
-                torrentBytes = await httpClient.GetByteArrayAsync(torrentUrl);
-                _logger.LogDebug("[Deluge] Downloaded {Bytes} bytes", torrentBytes.Length);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "[Deluge] Failed to download torrent file from URL (will fall back to add_torrent_url): {Url}", torrentUrl);
-            }
-
-            if (torrentBytes != null && torrentBytes.Length > 0)
-            {
-                // Preferred path: send torrent file as base64 via core.add_torrent_file
-                var base64Content = Convert.ToBase64String(torrentBytes);
-                _logger.LogDebug("[Deluge] Adding torrent file to Deluge via add_torrent_file");
-                response = await SendRpcRequestAsync(config, "core.add_torrent_file",
-                    new object[] { "download.torrent", base64Content, options });
-            }
-            else
-            {
-                // Fallback: let Deluge download the torrent from the URL directly
-                _logger.LogInformation("[Deluge] Falling back to add_torrent_url: {Url}", torrentUrl);
-                response = await SendRpcRequestAsync(config, "core.add_torrent_url",
-                    new object[] { torrentUrl, options });
-            }
+            var response = await SendRpcRequestAsync(config, method, buildParams(options));
 
             if (response == null)
             {

--- a/src/Services/DownloadClientService.cs
+++ b/src/Services/DownloadClientService.cs
@@ -637,7 +637,30 @@ public class DownloadClientService : IDownloadClientService
     private async Task<string?> AddToDelugeAsync(DownloadClient config, string url, string category, double? seedRatioLimit = null, int? seedTimeLimitMinutes = null)
     {
         var client = GetDelugeClient(config);
-        return await client.AddTorrentAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes);
+
+        // Magnet links go straight to Deluge via core.add_torrent_magnet.
+        if (TorrentHashHelper.IsMagnet(url))
+        {
+            return await client.AddTorrentMagnetAsync(config, url, category, seedRatioLimit, seedTimeLimitMinutes);
+        }
+
+        // Resolve the .torrent link here (following redirects manually) so a magnet
+        // redirect from a magnet-only indexer is caught and added via add_torrent_magnet.
+        // Deluge's own add_torrent_url can't follow a cross-scheme redirect to a magnet:
+        // URI and fails with "Unsupported scheme", so we never hand it the raw URL.
+        var resolved = await TorrentFileResolver.ResolveAsync(url, config.DisableSslCertificateValidation, _logger);
+        if (!resolved.IsSuccess)
+        {
+            _logger.LogError("[Download Client] Failed to resolve torrent for Deluge from {Url}: {Error}", url, resolved.ErrorMessage);
+            return null;
+        }
+
+        if (resolved.IsMagnetRedirect)
+        {
+            return await client.AddTorrentMagnetAsync(config, resolved.MagnetLink!, category, seedRatioLimit, seedTimeLimitMinutes);
+        }
+
+        return await client.AddTorrentFromBytesAsync(config, resolved.TorrentData!, category, seedRatioLimit, seedTimeLimitMinutes);
     }
 
     private async Task<string?> AddToRTorrentAsync(DownloadClient config, string url, string category, double? seedRatioLimit = null, int? seedTimeLimitMinutes = null)


### PR DESCRIPTION
## Problem

Manual (and automatic) grabs to **Deluge** fail for magnet-only indexers with:

```
[Download Client] Failed to add download: Download client returned null
```

The real cause, deeper in the logs, is a magnet redirect Deluge can't handle:

```
[Deluge] Failed to download torrent file from URL (will fall back to add_torrent_url): http://.../download?apikey=...
System.UriFormatException: Invalid URI: The hostname could not be parsed.
[Deluge] Falling back to add_torrent_url: http://.../download?apikey=...
[Deluge] RPC returned error: ... twisted.web.error.SchemeNotSupported: Unsupported scheme: b''
[Download Client] Failed to add download: Download client returned null
```

## Root cause

Magnet-only public indexers (e.g. **Knaben** proxied through Prowlarr) answer the `/download` URL with a 301/302 redirect to a `magnet:` URI.

`DelugeClient.AddTorrentAsync` was the only torrent-client path that did **not** route through `TorrentFileResolver`. Instead it:

1. Called `HttpClient.GetByteArrayAsync(url)`, which auto-follows the redirect to `magnet:` — and .NET can't parse a host out of a magnet URI → `UriFormatException`.
2. Fell back to `core.add_torrent_url`, handing Deluge the original URL. Deluge follows the redirect to the magnet itself, and its `download_file` rejects the magnet scheme → `Unsupported scheme: b''`.

Net result: the add returns `null`. Transmission, rTorrent and qBittorrent all avoid this by resolving the URL through `TorrentFileResolver` first (which follows redirects manually and surfaces a magnet redirect as a magnet link). Deluge simply never got wired up to it, and `DelugeClient` had no magnet path at all.

## Fix

- Route `AddToDelugeAsync` through `TorrentFileResolver`, mirroring the Transmission/rTorrent paths: a magnet (or magnet redirect) is added via `core.add_torrent_magnet`; a real `.torrent` is added from the resolved bytes via `core.add_torrent_file`. Deluge is never handed the raw redirecting URL.
- Replace the old fetch-then-`add_torrent_url` `AddTorrentAsync` with two explicit methods — `AddTorrentFromBytesAsync` (`core.add_torrent_file`) and `AddTorrentMagnetAsync` (`core.add_torrent_magnet`) — sharing a single `AddTorrentInternalAsync` helper that preserves all existing behavior (login, `add_paused`/`download_location` options, Label-plugin category, per-torrent seed limits, initial-state handling, result parsing).

No behavior change for `.torrent`-file indexers; magnet-only indexers now work.

## Verification

Ran the app locally against a **live Deluge 2.2.0 + Prowlarr** and triggered a manual grab on a Knaben magnet-redirect release:

```
[Torrent Download] Redirect to magnet link detected: magnet:?xt=urn:btih:A0A825FA...
[Deluge] Adding magnet to Deluge via add_torrent_magnet
[Deluge] RPC ... core.add_torrent_magnet -> Status=OK
[Deluge] Torrent added successfully: a0a825fa1c50189eb9235df4c63640414ff8e0d0
[GRAB] AddDownloadWithResultAsync returned: Success=true, DownloadId=a0a825fa...
[GRAB] ========== DOWNLOAD GRAB COMPLETE ==========
```

The old `Unsupported scheme` / `returned null` failure is gone; the torrent is added and queued. `dotnet build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
