### PR TITLE
fix(cors): move UseCors after UseRouting so endpoint RequireCors works

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -536,8 +536,6 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseCors();
-
 // Per-IP rate limiting (currently applied to the login endpoint to slow brute force).
 app.UseRateLimiter();
 
@@ -584,6 +582,14 @@ app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks
 // This ensures API endpoints are matched to handlers before the SPA fallback
 // middleware runs, preventing API routes from being served index.html.
 app.UseRouting();
+
+// CORS must run AFTER UseRouting so the matched endpoint's RequireCors metadata is
+// visible, and before the endpoint executes. Because the app calls UseRouting()
+// explicitly (which suppresses WebApplication's auto-injected routing), a UseCors()
+// placed before it never applied to endpoint-scoped policies (e.g. /api/health's
+// PublicProbe) — ASP.NET then rejected those requests with HTTP 400 "endpoint contains
+// CORS metadata, but a middleware was not found that supports CORS".
+app.UseCors();
 
 // Configure static files (UI from wwwroot)
 // For URL base support, we need to inject the urlBase into index.html


### PR DESCRIPTION
## Problem

Endpoints tagged with `.RequireCors(...)` fail with:

> HTTP 400 — *"Endpoint HTTP: GET /api/health contains CORS metadata, but a middleware was not found that supports CORS. Configure your application startup by adding app.UseCors()..."*

The most visible impact: the **Jellyfin/Plex/Emby plugins' "Test Connection"** button probes `{ApiUrl}/api/health` (which is declared with `.RequireCors(PublicProbeCorsPolicy)`), so pointing any of those plugins at a **local Sportarr instance** fails.

## Cause

`Program.cs` calls `app.UseRouting()` **explicitly** (to match API routes before the SPA fallback). That suppresses `WebApplication`'s auto-injected routing middleware. `app.UseCors()` was placed *before* that explicit `UseRouting()`, so the CORS middleware ran **before** the endpoint was selected — it never saw the matched endpoint's `RequireCors` metadata, and ASP.NET rejected the request.

For endpoint-scoped CORS, `UseCors()` must sit **between** `UseRouting()` and endpoint execution.

## Fix

Move `app.UseCors()` to immediately **after** `app.UseRouting()`. One-line move (the diff is +8/−2 only because of the explanatory comment). `AddCors`, the `PublicProbe` policy, and the default policy are all unchanged.

Verified: `/api/health` returns `200` + JSON instead of the 400, and the media-server plugin Test Connection succeeds against a local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)