### PR TITLE
Fix API key never exposed to the UI in external auth mode (#1)

### DIFF
--- a/src/Middleware/DynamicAuthenticationMiddleware.cs
+++ b/src/Middleware/DynamicAuthenticationMiddleware.cs
@@ -287,7 +287,9 @@ public class DynamicAuthenticationMiddleware
                path.EndsWith(".ico");
     }
 
-    private bool IsLocalAddress(HttpContext context)
+    // Static so the /initialize.json and index.html key-exposure gate in Program.cs
+    // can reuse the exact same local-address decision as the auth middleware.
+    public static bool IsLocalAddress(HttpContext context)
     {
         // Fail closed when the request arrived through a reverse proxy.
         // The "disabledForLocalAddresses" decision is based on the raw TCP peer
@@ -336,7 +338,7 @@ public class DynamicAuthenticationMiddleware
                headers.ContainsKey("X-Forwarded-Host");
     }
 
-    private bool IsPrivateClass172(string ipString)
+    private static bool IsPrivateClass172(string ipString)
     {
         var parts = ipString.Split('.');
         if (parts.Length < 2) return false;
@@ -353,7 +355,7 @@ public class DynamicAuthenticationMiddleware
     /// Get username from external auth proxy headers
     /// Supports common headers used by oauth-proxy, Authelia, Authentik, Traefik Forward Auth, etc.
     /// </summary>
-    private string? GetExternalAuthUser(HttpContext context)
+    public static string? GetExternalAuthUser(HttpContext context)
     {
         // Common headers used by various auth proxies
         // Priority order: most specific to most generic

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -895,16 +895,20 @@ app.MapGet("/initialize.json", async (HttpContext httpContext, Sportarr.Api.Serv
 
 // Decide whether the master API key may be returned to the current caller.
 // Safe to expose when UI auth is disabled ("none" – there is no auth boundary to defeat),
-// or when the request itself is already authenticated via the API key or a Forms session.
+// when a reverse proxy has already authenticated the request ("external"), or when the
+// request itself is already authenticated via the API key or a Forms session.
 static async Task<bool> ShouldExposeApiKeyAsync(HttpContext context, SportarrDbContext db)
 {
     var authMethod = "none";
+    var authRequired = "disabledForLocalAddresses";
     var appSettings = await db.AppSettings.FirstOrDefaultAsync();
     if (appSettings != null)
     {
         try
         {
-            authMethod = JsonSerializer.Deserialize<SecuritySettings>(appSettings.SecuritySettings)?.AuthenticationMethod ?? "none";
+            var securitySettings = JsonSerializer.Deserialize<SecuritySettings>(appSettings.SecuritySettings);
+            authMethod = securitySettings?.AuthenticationMethod ?? "none";
+            authRequired = securitySettings?.AuthenticationRequired ?? "disabledForLocalAddresses";
         }
         catch
         {
@@ -922,6 +926,25 @@ static async Task<bool> ShouldExposeApiKeyAsync(HttpContext context, SportarrDbC
     if (apiResult.Succeeded)
     {
         return true;
+    }
+
+    // External mode delegates authentication to a reverse proxy (oauth2-proxy,
+    // Authelia, Authentik, ...). A browser behind the proxy has no forms session
+    // and no key to send, so without this branch the UI can never obtain the key
+    // and every write action fails. Mirror the middleware's trust decision: the
+    // proxy's auth headers mean the request was already authenticated upstream,
+    // and a direct connection without them keeps the middleware's local-address
+    // allowance. /initialize.json is a public path, so this gate — not the
+    // middleware — is what stands between an anonymous caller and the key.
+    if (authMethod == "external")
+    {
+        if (!string.IsNullOrEmpty(Sportarr.Api.Middleware.DynamicAuthenticationMiddleware.GetExternalAuthUser(context)))
+        {
+            return true;
+        }
+
+        return authRequired == "disabledForLocalAddresses" &&
+               Sportarr.Api.Middleware.DynamicAuthenticationMiddleware.IsLocalAddress(context);
     }
 
     var formsResult = await context.AuthenticateAsync("Forms");


### PR DESCRIPTION
With AuthenticationMethod set to "external", DynamicAuthenticationMiddleware trusts the reverse proxy's auth headers and lets requests through, but ShouldExposeApiKeyAsync had no branch for external mode. A browser behind the proxy has no forms session and no key to send, so /initialize.json (and the window.Sportarr injection in index.html) always returned an empty apiKey, and every UI write action failed with "API key not found in initialize data".

Expose the key in external mode when the request carries the proxy auth headers (same check the middleware uses to trust the request), falling back to the middleware's local-address allowance for direct connections. /initialize.json is a public path, so the gate performs the header check itself rather than assuming the middleware already enforced it.


Claude-Session: https://claude.ai/code/session_01C82VKft5LZcJQKSVgMBukC