### PR TITLE
fix(rtorrent): use d.base_path for import path on multi-file torrents

### DIFF
--- a/src/Services/RTorrentClient.cs
+++ b/src/Services/RTorrentClient.cs
@@ -195,7 +195,7 @@ public class RTorrentClient
             // Use d.multicall2 to get all torrents with multiple fields
             var fields = new[] { "d.hash=", "d.name=", "d.size_bytes=", "d.completed_bytes=",
                                 "d.up.total=", "d.state=", "d.down.rate=", "d.up.rate=",
-                                "d.directory=", "d.custom1=", "d.creation_date=" };
+                                "d.directory=", "d.base_path=", "d.custom1=", "d.creation_date=" };
 
             var response = await SendXmlRpcRequestAsync(config, "d.multicall2", new object[] { "", "main" }.Concat(fields).ToArray());
 
@@ -316,8 +316,9 @@ public class RTorrentClient
                 // State: 0=stopped, 1=started. CompletedBytes >= TotalSize means done.
                 var isCompleted = torrent.TotalSize > 0 && torrent.CompletedBytes >= torrent.TotalSize;
 
-                var savePath = !string.IsNullOrEmpty(torrent.Directory) && !string.IsNullOrEmpty(torrent.Name)
-                    ? System.IO.Path.Combine(torrent.Directory, torrent.Name)
+                // d.base_path is the file (single-file) or data root (multi-file); Path.Combine(dir, name) would yield dir/dir for multi-file.
+                var savePath = !string.IsNullOrEmpty(torrent.BasePath)
+                    ? torrent.BasePath
                     : torrent.Directory;
 
                 results.Add(new ExternalDownloadInfo
@@ -388,10 +389,9 @@ public class RTorrentClient
             timeRemaining = TimeSpan.FromSeconds(secondsRemaining);
         }
 
-        // Append torrent name so the returned path points at the actual torrent
-        // file/folder rather than the parent download directory.
-        var computedSavePath = !string.IsNullOrEmpty(torrent.Name)
-            ? Path.Combine(torrent.Directory, torrent.Name)
+        // d.base_path is the file (single-file) or data root (multi-file); Path.Combine(dir, name) would yield dir/dir for multi-file.
+        var computedSavePath = !string.IsNullOrEmpty(torrent.BasePath)
+            ? torrent.BasePath
             : torrent.Directory;
 
         return new DownloadClientStatus
@@ -544,7 +544,7 @@ public class RTorrentClient
             {
                 var values = data.Descendants("value").Select(v => v.Value).ToArray();
 
-                if (values.Length >= 11)
+                if (values.Length >= 12)
                 {
                     torrents.Add(new RTorrentTorrent
                     {
@@ -557,8 +557,9 @@ public class RTorrentClient
                         DownloadRate = long.TryParse(values[6], out var dlRate) ? dlRate : 0,
                         UploadRate = long.TryParse(values[7], out var ulRate) ? ulRate : 0,
                         Directory = values[8],
-                        Label = values[9],
-                        TimeAdded = long.TryParse(values[10], out var added) ? added : 0
+                        BasePath = values[9],
+                        Label = values[10],
+                        TimeAdded = long.TryParse(values[11], out var added) ? added : 0
                     });
                 }
             }
@@ -586,6 +587,7 @@ public class RTorrentTorrent
     public long DownloadRate { get; set; } // bytes/s
     public long UploadRate { get; set; } // bytes/s
     public string Directory { get; set; } = "";
+    public string BasePath { get; set; } = ""; // d.base_path: file path (single-file) or data root (multi-file)
     public string Label { get; set; } = "";
     public long TimeAdded { get; set; } // Unix timestamp
 }

--- a/tests/Sportarr.Api.Tests/Services/RTorrentClientAddTorrentTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/RTorrentClientAddTorrentTests.cs
@@ -84,6 +84,7 @@ public class RTorrentClientAddTorrentTests
                     <value><i8>0</i8></value>
                     <value><i8>0</i8></value>
                     <value><string>/downloads</string></value>
+                    <value><string>/downloads/{t.name}</string></value>
                     <value><string>sportarr</string></value>
                     <value><i8>0</i8></value>
                 </data></array></value>"));

--- a/tests/Sportarr.Api.Tests/Services/RTorrentClientPathResolutionTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/RTorrentClientPathResolutionTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using System.Text;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Regression coverage for a multi-file torrent import failure: the previous
+/// implementation built the import path as Path.Combine(d.directory, d.name),
+/// which is correct for single-file torrents (d.name is the file name, e.g.
+/// "Release.mkv") but wrong for multi-file torrents. For multi-file torrents
+/// d.name is the top-level directory name (no extension), so the combination
+/// yields "dir/dir" — a path that does not exist — and the import fails with
+/// "Download path not found or not accessible".
+///
+/// The fix fetches d.base_path= in the multicall and uses it directly.
+/// d.base_path is the full file path for single-file torrents and the data
+/// root directory for multi-file torrents, so it is correct in both cases
+/// without any branching. These tests pin that contract via
+/// GetTorrentStatusAsync, the path that feeds ImportDownloadAsync.
+/// </summary>
+public class RTorrentClientPathResolutionTests
+{
+    private const string MultiFileHash = "1618E51EAF08A530C7122BF4A6562BF7A743D0BD";
+    private const string SingleFileHash = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+    private static DownloadClient MakeConfig() => new()
+    {
+        Name = "Test rTorrent",
+        Type = DownloadClientType.RTorrent,
+        Host = "localhost",
+        Port = 8080,
+        Directory = "/home/nicholos/dataUnfinished"
+    };
+
+    private class FakeRTorrentHandler : HttpMessageHandler
+    {
+        private readonly Func<string, string> _responder;
+
+        public FakeRTorrentHandler(Func<string, string> responder) => _responder = responder;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responder(body), Encoding.UTF8, "text/xml")
+            };
+        }
+    }
+
+    // Field order matches RTorrentClient.GetTorrentsAsync multicall:
+    // hash, name, size, completed, uploaded, state, dlrate, ulrate, directory,
+    // base_path, custom1(label), creation_date.
+    private static string BuildMulticallResponse(TorrentRow t) => $@"<?xml version=""1.0""?>
+<methodResponse><params><param><value><array><data>
+    <value><array><data>
+        <value><string>{t.Hash}</string></value>
+        <value><string>{t.Name}</string></value>
+        <value><i8>{t.Size}</i8></value>
+        <value><i8>{t.Completed}</i8></value>
+        <value><i8>0</i8></value>
+        <value><i4>1</i4></value>
+        <value><i8>0</i8></value>
+        <value><i8>0</i8></value>
+        <value><string>{t.Directory}</string></value>
+        <value><string>{t.BasePath}</string></value>
+        <value><string>sportarr</string></value>
+        <value><i8>0</i8></value>
+    </data></array></value>
+</data></array></value></param></params></methodResponse>";
+
+    private sealed record TorrentRow(string Hash, string Name, string Directory, string BasePath, long Size, long Completed);
+
+    private static RTorrentClient CreateClient(Func<string, string> responder) =>
+        new(new HttpClient(new FakeRTorrentHandler(responder)), NullLogger<RTorrentClient>.Instance);
+
+    // Multi-file: d.name is the top-level directory name (no extension);
+    // d.directory and d.base_path are both the data root.
+    private static TorrentRow MultiFileTorrent() => new(
+        MultiFileHash,
+        "Formula1.2026.Round11.Hungary.Race.F1LIVE.F1TV.WEB-DL.1080p.H264.English-MWR",
+        "/home/nicholos/data/Formula1.2026.Round11.Hungary.Race.F1LIVE.F1TV.WEB-DL.1080p.H264.English-MWR",
+        "/home/nicholos/data/Formula1.2026.Round11.Hungary.Race.F1LIVE.F1TV.WEB-DL.1080p.H264.English-MWR",
+        6380797814, 6380797814);
+
+    // Single-file: d.name is the file name (with extension);
+    // d.directory is the parent dir, d.base_path is the full file path.
+    private static TorrentRow SingleFileTorrent() => new(
+        SingleFileHash,
+        "03.NASCAR.Cup.Series.2026.R22.Brickyard.400.Race.TNT.1080P.mkv",
+        "/home/nicholos/data",
+        "/home/nicholos/data/03.NASCAR.Cup.Series.2026.R22.Brickyard.400.Race.TNT.1080P.mkv",
+        11394324034, 11394324034);
+
+    [Fact]
+    public async Task GetTorrentStatus_UsesBasePath_ForMultiFileTorrent()
+    {
+        // Path.Combine(directory, name) would yield dir/dir (non-existent) here.
+        var torrent = MultiFileTorrent();
+        var client = CreateClient(_ => BuildMulticallResponse(torrent));
+
+        var status = await client.GetTorrentStatusAsync(MakeConfig(), MultiFileHash);
+
+        status.Should().NotBeNull();
+        status!.SavePath.Should().Be(torrent.BasePath);
+        status.SavePath.Should().NotBe(System.IO.Path.Combine(torrent.Directory, torrent.Name));
+    }
+
+    [Fact]
+    public async Task GetTorrentStatus_UsesBasePath_ForSingleFileTorrent()
+    {
+        var torrent = SingleFileTorrent();
+        var client = CreateClient(_ => BuildMulticallResponse(torrent));
+
+        var status = await client.GetTorrentStatusAsync(MakeConfig(), SingleFileHash);
+
+        status.Should().NotBeNull();
+        status!.SavePath.Should().Be(torrent.BasePath);
+        status.SavePath.Should().EndWith(".mkv");
+    }
+}


### PR DESCRIPTION
## Problem

Multi-file torrents fail to import with:

```
[ERR] Download path not found or not accessible: /home/nicholos/data/<name>/<name>
```

The import path was built as `Path.Combine(d.directory, d.name)`. This is correct for **single-file** torrents (where `d.name` is the file name, e.g. `Release.mkv`), but wrong for **multi-file** torrents — there `d.name` is the top-level **directory** name (no extension), so the combination yields `dir/dir`, a path that does not exist.

## Evidence (verified against rTorrent 0.9.8)

| Field | Single-file (imports OK) | Multi-file (fails) |
|---|---|---|
| `d.name` | `Release.mkv` | `Release` (dir name, no ext) |
| `d.directory` | `/home/.../data` (parent) | `/home/.../data/Release` (data root) |
| `d.is_multi_file` | 0 | 1 |
| `d.base_path` | `/home/.../data/Release.mkv` ✓ | `/home/.../data/Release` ✓ |

`d.base_path` returns the correct path in both cases — the full file path for single-file torrents, and the data root directory for multi-file torrents.

## Fix

Fetch `d.base_path=` in the `d.multicall2` query and use it directly instead of `Path.Combine(d.directory, d.name)`. Falls back to `d.directory` if `d.base_path` is empty (defensive for stopped-torrent edge cases).

Scoped to `RTorrentClient` only — did not touch Deluge/Transmission, which have similar-looking code but no verified failing case.

## Changes

- `src/Services/RTorrentClient.cs`: added `d.base_path=` to multicall fields, `BasePath` to the `RTorrentTorrent` model, updated `ParseMulticallResponse` (field index 9, shifted Label/TimeAdded), replaced both `Path.Combine(directory, name)` sites with `torrent.BasePath`.
- `tests/Sportarr.Api.Tests/Services/RTorrentClientAddTorrentTests.cs`: added `base_path` field to the `BuildMulticallResponse` helper.
- `tests/Sportarr.Api.Tests/Services/RTorrentClientPathResolutionTests.cs` (new): regression tests for multi-file (path = data root, not dir/dir) and single-file (path = file with .mkv) via `GetTorrentStatusAsync`.

## Verification

- `dotnet build Sportarr.sln` — 0 errors
- `dotnet test` — 818 passed, 0 failed