### PR TITLE
fix: apply remote path mappings for external downloads

### DIFF
--- a/src/Services/EnhancedDownloadMonitorService.cs
+++ b/src/Services/EnhancedDownloadMonitorService.cs
@@ -1,6 +1,7 @@
 using Sportarr.Api.Data;
 using Sportarr.Api.Helpers;
 using Sportarr.Api.Models;
+using Sportarr.Api.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Sportarr.Api.Services;
@@ -1134,10 +1135,14 @@ public class EnhancedDownloadMonitorService : BackgroundService
                     string? scanFolder = null;
                     if (download.IsCompleted && !string.IsNullOrEmpty(download.FilePath))
                     {
-                        if (Directory.Exists(download.FilePath))
-                            scanFolder = download.FilePath;
-                        else if (File.Exists(download.FilePath))
-                            scanFolder = Path.GetDirectoryName(download.FilePath);
+                        using var pathScope = _serviceProvider.CreateScope();
+                        var pathMapping = pathScope.ServiceProvider.GetRequiredService<IRemotePathMappingService>();
+                        var localFilePath = await pathMapping.RemapRemoteToLocalAsync(client.Host, download.FilePath);
+
+                        if (Directory.Exists(localFilePath))
+                            scanFolder = localFilePath;
+                        else if (File.Exists(localFilePath))
+                            scanFolder = Path.GetDirectoryName(localFilePath);
                     }
 
                     if (scanFolder != null)

--- a/src/Services/FileImportService.cs
+++ b/src/Services/FileImportService.cs
@@ -74,6 +74,7 @@ public class FileImportService : IFileImportService
     private readonly SportarrApiClient _sportarrApiClient;
     private readonly NotificationService _notificationService;
     private readonly CustomFormatService _customFormatService;
+    private readonly IRemotePathMappingService _pathMappingService;
     private readonly ILogger<FileImportService> _logger;
 
     private static readonly string[] VideoExtensions = SupportedExtensions.Video;
@@ -89,6 +90,7 @@ public class FileImportService : IFileImportService
         SportarrApiClient sportarrApiClient,
         NotificationService notificationService,
         CustomFormatService customFormatService,
+        IRemotePathMappingService pathMappingService,
         ILogger<FileImportService> logger)
     {
         _db = db;
@@ -101,6 +103,7 @@ public class FileImportService : IFileImportService
         _sportarrApiClient = sportarrApiClient;
         _notificationService = notificationService;
         _customFormatService = customFormatService;
+        _pathMappingService = pathMappingService;
         _logger = logger;
     }
 
@@ -2033,7 +2036,7 @@ public class FileImportService : IFileImportService
 
             // Translate remote path to local path using Remote Path Mappings
             // This handles Docker volume mapping differences (e.g., /data/usenet → /downloads)
-            var localPath = await TranslatePathAsync(status.SavePath, downloadClient.Host);
+            var localPath = await _pathMappingService.RemapRemoteToLocalAsync(downloadClient.Host, status.SavePath);
 
             _logger.LogInformation("[PathMapping] Final path for import: '{LocalPath}'", localPath);
             _logger.LogInformation("[PathMapping] ========== PATH TRANSLATION END ==========");
@@ -2043,93 +2046,6 @@ public class FileImportService : IFileImportService
         // Fallback to default path if status doesn't include it
         _logger.LogWarning("[PathMapping] Could not get save path from download client status, using fallback path");
         return Path.Combine(Path.GetTempPath(), "downloads", download.DownloadId);
-    }
-
-    /// <summary>
-    /// Translate remote path to local path using Remote Path Mappings.
-    /// Required when download client uses different path structure than Sportarr.
-    /// Example: Download client reports "/data/usenet/sports/" but Sportarr sees it as "/downloads/sports/".
-    /// </summary>
-    private async Task<string> TranslatePathAsync(string remotePath, string host)
-    {
-        _logger.LogInformation("[PathMapping] Starting path translation for host '{Host}'", host);
-        _logger.LogInformation("[PathMapping] Remote path from download client: '{RemotePath}'", remotePath);
-
-        // Get all path mappings and filter in memory (EF can't translate StringComparison to SQL)
-        // Since there are typically very few remote path mappings, loading all is fine
-        var allMappings = await _db.RemotePathMappings.ToListAsync();
-        _logger.LogInformation("[PathMapping] Total configured mappings in database: {Count}", allMappings.Count);
-
-        // Log all configured mappings for debugging
-        foreach (var m in allMappings)
-        {
-            _logger.LogInformation("[PathMapping] Configured mapping: Host='{Host}', RemotePath='{RemotePath}' → LocalPath='{LocalPath}'",
-                m.Host, m.RemotePath, m.LocalPath);
-        }
-
-        var mappings = allMappings
-            .Where(m => m.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(m => m.RemotePath.Length) // Longest match first (most specific)
-            .ToList();
-
-        _logger.LogInformation("[PathMapping] Mappings matching host '{Host}': {Count}", host, mappings.Count);
-
-        foreach (var mapping in mappings)
-        {
-            // Check if remote path starts with this mapping's remote path
-            var remoteMappingPath = mapping.RemotePath.TrimEnd('/', '\\');
-            var remoteCheckPath = remotePath.Replace('\\', '/').TrimEnd('/');
-            var normalizedMappingPath = remoteMappingPath.Replace('\\', '/');
-
-            _logger.LogInformation("[PathMapping] Checking mapping: Does '{RemoteCheckPath}' start with '{NormalizedMapping}'?",
-                remoteCheckPath, normalizedMappingPath);
-
-            if (remoteCheckPath.StartsWith(normalizedMappingPath, StringComparison.OrdinalIgnoreCase))
-            {
-                // Replace remote path with local path
-                var relativePath = remoteCheckPath.Substring(remoteMappingPath.Length).TrimStart('/');
-
-                // Use forward slashes for path joining to ensure Linux compatibility in Docker
-                // Path.Combine can have issues with mixed separators
-                var localBasePath = mapping.LocalPath.TrimEnd('/', '\\');
-                var localPath = string.IsNullOrEmpty(relativePath)
-                    ? localBasePath
-                    : $"{localBasePath}/{relativePath}";
-
-                _logger.LogInformation("[PathMapping] ✓ MATCH! Remote path mapped: '{Remote}' → '{Local}'", remotePath, localPath);
-                _logger.LogInformation("[PathMapping] Mapping details: RemotePath='{MappingRemote}', LocalPath='{MappingLocal}', RelativePath='{RelativePath}'",
-                    mapping.RemotePath, mapping.LocalPath, relativePath);
-
-                // Verify the translated path exists
-                var pathExists = Directory.Exists(localPath) || File.Exists(localPath);
-                _logger.LogInformation("[PathMapping] Translated path exists: {Exists}", pathExists);
-                if (!pathExists)
-                {
-                    _logger.LogWarning("[PathMapping] WARNING: Translated path does not exist! File may not be ready or mapping may be incorrect.");
-                }
-
-                return localPath;
-            }
-            else
-            {
-                _logger.LogInformation("[PathMapping] ✗ No match for this mapping");
-            }
-        }
-
-        // No mapping found - this is normal if Docker volumes are mapped correctly
-        // Remote Path Mapping is only needed when paths differ between download client and Sportarr
-        _logger.LogWarning("[PathMapping] No matching path mapping found for host '{Host}' and path '{RemotePath}'", host, remotePath);
-        _logger.LogInformation("[PathMapping] Using path as-is (this is fine if paths already match between download client and Sportarr)");
-
-        // Check if the unmapped path exists
-        var unmappedPathExists = Directory.Exists(remotePath) || File.Exists(remotePath);
-        _logger.LogInformation("[PathMapping] Unmapped path exists: {Exists}", unmappedPathExists);
-        if (!unmappedPathExists)
-        {
-            _logger.LogWarning("[PathMapping] WARNING: Path does not exist! You may need to configure a Remote Path Mapping in Settings → Download Clients");
-        }
-
-        return remotePath;
     }
 
     /// <summary>

--- a/src/Services/ImportService.cs
+++ b/src/Services/ImportService.cs
@@ -2,6 +2,7 @@ using Sportarr.Api.Data;
 using Sportarr.Api.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Text.RegularExpressions;
+using Sportarr.Api.Services.Interfaces;
 
 namespace Sportarr.Api.Services;
 
@@ -18,6 +19,7 @@ public class ImportService
 {
     private readonly SportarrDbContext _db;
     private readonly ConfigService _configService;
+    private readonly IRemotePathMappingService _pathMappingService;
     private readonly ILogger<ImportService> _logger;
 
     private static readonly string[] VideoExtensions = SupportedExtensions.Video;
@@ -25,10 +27,12 @@ public class ImportService
     public ImportService(
         SportarrDbContext db,
         ConfigService configService,
+        IRemotePathMappingService pathMappingService,
         ILogger<ImportService> logger)
     {
         _db = db;
         _configService = configService;
+        _pathMappingService = pathMappingService;
         _logger = logger;
     }
 
@@ -57,7 +61,7 @@ public class ImportService
             _logger.LogInformation("[Import] Remote path: {RemotePath}", remotePath);
 
             // Translate remote path to local path using path mappings
-            var localPath = await TranslatePathAsync(remotePath, downloadClientHost);
+            var localPath = await _pathMappingService.RemapRemoteToLocalAsync(downloadClientHost, remotePath);
             _logger.LogInformation("[Import] Local path: {LocalPath}", localPath);
 
             // Find video file in the download
@@ -253,74 +257,6 @@ public class ImportService
         return await _db.DownloadQueue
             .Include(dq => dq.DownloadClient)
             .FirstOrDefaultAsync(dq => dq.DownloadId == downloadId);
-    }
-
-    /// <summary>
-    /// Translate remote path to local path using Remote Path Mappings
-    /// </summary>
-    private async Task<string> TranslatePathAsync(string remotePath, string host)
-    {
-        _logger.LogInformation("[PathMapping] Starting path translation for host '{Host}'", host);
-        _logger.LogInformation("[PathMapping] Remote path from download client: '{RemotePath}'", remotePath);
-
-        // Get all path mappings for this host
-        var allMappings = await _db.RemotePathMappings.ToListAsync();
-        _logger.LogInformation("[PathMapping] Total configured mappings: {Count}", allMappings.Count);
-
-        foreach (var m in allMappings)
-        {
-            _logger.LogInformation("[PathMapping] Configured mapping: Host='{Host}', RemotePath='{RemotePath}' → LocalPath='{LocalPath}'",
-                m.Host, m.RemotePath, m.LocalPath);
-        }
-
-        var mappings = allMappings
-            .Where(m => m.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(m => m.RemotePath.Length) // Longest match first
-            .ToList();
-
-        _logger.LogInformation("[PathMapping] Mappings matching host '{Host}': {Count}", host, mappings.Count);
-
-        foreach (var mapping in mappings)
-        {
-            // Check if remote path starts with this mapping's remote path
-            var remoteMappingPath = mapping.RemotePath.TrimEnd('/', '\\');
-            var remoteCheckPath = remotePath.Replace('\\', '/').TrimEnd('/');
-            var normalizedMappingPath = remoteMappingPath.Replace('\\', '/');
-
-            _logger.LogInformation("[PathMapping] Checking: Does '{RemoteCheckPath}' start with '{NormalizedMapping}'?",
-                remoteCheckPath, normalizedMappingPath);
-
-            if (remoteCheckPath.StartsWith(normalizedMappingPath, StringComparison.OrdinalIgnoreCase))
-            {
-                // Replace remote path with local path
-                var relativePath = remoteCheckPath.Substring(remoteMappingPath.Length).TrimStart('/');
-                var localPath = Path.Combine(mapping.LocalPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
-
-                _logger.LogInformation("[PathMapping] ✓ MATCH! Path mapped: {Remote} → {Local}", remotePath, localPath);
-
-                // Check if path exists
-                var pathExists = Directory.Exists(localPath) || File.Exists(localPath);
-                _logger.LogInformation("[PathMapping] Translated path exists: {Exists}", pathExists);
-                if (!pathExists)
-                {
-                    _logger.LogWarning("[PathMapping] WARNING: Translated path does not exist!");
-                }
-
-                return localPath;
-            }
-            else
-            {
-                _logger.LogInformation("[PathMapping] ✗ No match");
-            }
-        }
-
-        // No mapping found, return as-is
-        _logger.LogWarning("[PathMapping] No matching path mapping found for host '{Host}' and path '{RemotePath}'", host, remotePath);
-
-        var unmappedPathExists = Directory.Exists(remotePath) || File.Exists(remotePath);
-        _logger.LogInformation("[PathMapping] Unmapped path exists: {Exists}", unmappedPathExists);
-
-        return remotePath;
     }
 
     /// <summary>

--- a/src/Services/Interfaces/IRemotePathMappingService.cs
+++ b/src/Services/Interfaces/IRemotePathMappingService.cs
@@ -1,0 +1,17 @@
+namespace Sportarr.Api.Services.Interfaces;
+
+/// <summary>
+/// Translates download-client-reported paths to local paths using
+/// RemotePathMappings. Required when the download client runs on a
+/// different host or in a different container (e.g. rTorrent on a
+/// seedbox reports /home/nicholos/data/ but Sportarr sees /data/seedbox-data/).
+/// </summary>
+public interface IRemotePathMappingService
+{
+    /// <summary>
+    /// Translate a remote path reported by the download client to the
+    /// local path Sportarr should use. If no mapping matches, returns
+    /// the path unchanged.
+    /// </summary>
+    Task<string> RemapRemoteToLocalAsync(string host, string remotePath);
+}

--- a/src/Services/ProvideImportItemService.cs
+++ b/src/Services/ProvideImportItemService.cs
@@ -1,5 +1,6 @@
 using Sportarr.Api.Data;
 using Sportarr.Api.Models;
+using Sportarr.Api.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace Sportarr.Api.Services;
@@ -12,13 +13,16 @@ namespace Sportarr.Api.Services;
 public class ProvideImportItemService
 {
     private readonly SportarrDbContext _db;
+    private readonly IRemotePathMappingService _pathMappingService;
     private readonly ILogger<ProvideImportItemService> _logger;
 
     public ProvideImportItemService(
         SportarrDbContext db,
+        IRemotePathMappingService pathMappingService,
         ILogger<ProvideImportItemService> logger)
     {
         _db = db;
+        _pathMappingService = pathMappingService;
         _logger = logger;
     }
 
@@ -47,7 +51,7 @@ public class ProvideImportItemService
         }
 
         // Translate the remote path to local path using remote path mappings
-        var localPath = await TranslatePathAsync(remotePath, downloadClient.Host);
+        var localPath = await _pathMappingService.RemapRemoteToLocalAsync(downloadClient.Host, remotePath);
 
         // Validate the path
         var validation = ValidatePath(localPath);
@@ -58,67 +62,6 @@ public class ProvideImportItemService
             IsValid = validation.IsValid,
             ValidationMessage = validation.Message
         };
-    }
-
-    /// <summary>
-    /// Translate remote path to local path using Remote Path Mappings
-    /// Required when download client uses different path structure than Sportarr
-    /// </summary>
-    private async Task<string> TranslatePathAsync(string remotePath, string host)
-    {
-        _logger.LogInformation("[PathMapping] Starting path translation for host '{Host}'", host);
-        _logger.LogInformation("[PathMapping] Remote path from download client: '{RemotePath}'", remotePath);
-
-        // Get all path mappings and filter in memory
-        var allMappings = await _db.RemotePathMappings.ToListAsync();
-        _logger.LogInformation("[PathMapping] Total configured mappings: {Count}", allMappings.Count);
-
-        foreach (var m in allMappings)
-        {
-            _logger.LogInformation("[PathMapping] Configured mapping: Host='{Host}', RemotePath='{RemotePath}' → LocalPath='{LocalPath}'",
-                m.Host, m.RemotePath, m.LocalPath);
-        }
-
-        var mappings = allMappings
-            .Where(m => m.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(m => m.RemotePath.Length) // Longest match first (most specific)
-            .ToList();
-
-        _logger.LogInformation("[PathMapping] Mappings matching host '{Host}': {Count}", host, mappings.Count);
-
-        foreach (var mapping in mappings)
-        {
-            var remoteMappingPath = mapping.RemotePath.TrimEnd('/', '\\');
-            var remoteCheckPath = remotePath.Replace('\\', '/').TrimEnd('/');
-            var normalizedMappingPath = remoteMappingPath.Replace('\\', '/');
-
-            _logger.LogInformation("[PathMapping] Checking: Does '{RemoteCheckPath}' start with '{NormalizedMapping}'?",
-                remoteCheckPath, normalizedMappingPath);
-
-            if (remoteCheckPath.StartsWith(normalizedMappingPath, StringComparison.OrdinalIgnoreCase))
-            {
-                var relativePath = remoteCheckPath.Substring(remoteMappingPath.Length).TrimStart('/');
-                var localPath = Path.Combine(mapping.LocalPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
-
-                _logger.LogInformation("[PathMapping] ✓ MATCH! Path mapped: {Remote} → {Local}", remotePath, localPath);
-
-                var pathExists = Directory.Exists(localPath) || File.Exists(localPath);
-                _logger.LogInformation("[PathMapping] Translated path exists: {Exists}", pathExists);
-
-                return localPath;
-            }
-            else
-            {
-                _logger.LogInformation("[PathMapping] ✗ No match");
-            }
-        }
-
-        _logger.LogWarning("[PathMapping] No matching path mapping found for host '{Host}' and path '{RemotePath}'", host, remotePath);
-
-        var unmappedPathExists = Directory.Exists(remotePath) || File.Exists(remotePath);
-        _logger.LogInformation("[PathMapping] Unmapped path exists: {Exists}", unmappedPathExists);
-
-        return remotePath;
     }
 
     /// <summary>

--- a/src/Services/RemotePathMappingService.cs
+++ b/src/Services/RemotePathMappingService.cs
@@ -6,7 +6,7 @@ namespace Sportarr.Api.Services;
 
 /// <summary>
 /// Translates download-client-reported paths to local paths using
-/// RemotePathMappings. Mirrors Sonarr's RemotePathMappingService.
+/// RemotePathMappings.
 /// </summary>
 public class RemotePathMappingService : IRemotePathMappingService
 {
@@ -39,7 +39,10 @@ public class RemotePathMappingService : IRemotePathMappingService
             var normalizedRemote = remotePath.Replace('\\', '/').TrimEnd('/');
             var normalizedMapping = remoteBase.Replace('\\', '/');
 
-            if (normalizedRemote.StartsWith(normalizedMapping, StringComparison.OrdinalIgnoreCase))
+            // Match on whole path segments only: a mapping for /data must not
+            // claim /database/file.mkv.
+            if (normalizedRemote.Equals(normalizedMapping, StringComparison.OrdinalIgnoreCase) ||
+                normalizedRemote.StartsWith(normalizedMapping + "/", StringComparison.OrdinalIgnoreCase))
             {
                 var relativePath = normalizedRemote.Substring(remoteBase.Length).TrimStart('/');
                 var localPath = string.IsNullOrEmpty(relativePath)

--- a/src/Services/RemotePathMappingService.cs
+++ b/src/Services/RemotePathMappingService.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Sportarr.Api.Data;
+using Sportarr.Api.Services.Interfaces;
+
+namespace Sportarr.Api.Services;
+
+/// <summary>
+/// Translates download-client-reported paths to local paths using
+/// RemotePathMappings. Mirrors Sonarr's RemotePathMappingService.
+/// </summary>
+public class RemotePathMappingService : IRemotePathMappingService
+{
+    private readonly SportarrDbContext _db;
+    private readonly ILogger<RemotePathMappingService> _logger;
+
+    public RemotePathMappingService(SportarrDbContext db, ILogger<RemotePathMappingService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<string> RemapRemoteToLocalAsync(string host, string remotePath)
+    {
+        if (string.IsNullOrEmpty(remotePath))
+            return remotePath;
+
+        var allMappings = await _db.RemotePathMappings.ToListAsync();
+        if (allMappings.Count == 0)
+            return remotePath;
+
+        var mappings = allMappings
+            .Where(m => m.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(m => m.RemotePath.Length)
+            .ToList();
+
+        foreach (var mapping in mappings)
+        {
+            var remoteBase = mapping.RemotePath.TrimEnd('/', '\\');
+            var normalizedRemote = remotePath.Replace('\\', '/').TrimEnd('/');
+            var normalizedMapping = remoteBase.Replace('\\', '/');
+
+            if (normalizedRemote.StartsWith(normalizedMapping, StringComparison.OrdinalIgnoreCase))
+            {
+                var relativePath = normalizedRemote.Substring(remoteBase.Length).TrimStart('/');
+                var localPath = string.IsNullOrEmpty(relativePath)
+                    ? mapping.LocalPath.TrimEnd('/', '\\')
+                    : Path.Combine(mapping.LocalPath.TrimEnd('/', '\\'),
+                        relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+                _logger.LogDebug("Remapped remote path [{Remote}] to local path [{Local}] for host [{Host}]",
+                    remotePath, localPath, host);
+                return localPath;
+            }
+        }
+
+        return remotePath;
+    }
+}

--- a/src/Startup/ServiceCollectionExtensions.cs
+++ b/src/Startup/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Sportarr.Api.Data;
 using Sportarr.Api.Health;
 using Sportarr.Api.Middleware;
 using Sportarr.Api.Services;
+using Sportarr.Api.Services.Interfaces;
 using Sportarr.Api.Validators;
 using System.Net.Http;
 using System.Reflection;
@@ -311,6 +312,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<PathRemapService>();
         services.AddScoped<LibraryRescanService>();
         services.AddScoped<RestoreReconciliationService>();
+        services.AddScoped<IRemotePathMappingService, RemotePathMappingService>();
 
         return services;
     }

--- a/tests/Sportarr.Api.Tests/Services/RemotePathMappingServiceTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/RemotePathMappingServiceTests.cs
@@ -1,0 +1,174 @@
+using Sportarr.Api.Data;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Covers RemotePathMappingService.RemapRemoteToLocalAsync, the shared
+/// translation used by import and download monitoring when a download client
+/// reports paths from another host or container. Pins down host matching,
+/// longest-prefix-wins ordering, trailing-slash tolerance, Windows-style
+/// separators, and the segment-boundary rule (a mapping for /data must not
+/// claim /database/...).
+/// </summary>
+public class RemotePathMappingServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public RemotePathMappingServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private SportarrDbContext CreateDb()
+    {
+        var db = new SportarrDbContext(new DbContextOptionsBuilder<SportarrDbContext>()
+            .UseSqlite(_connection)
+            .Options);
+        db.Database.EnsureCreated();
+        return db;
+    }
+
+    private static RemotePathMappingService CreateService(SportarrDbContext db)
+        => new(db, NullLogger<RemotePathMappingService>.Instance);
+
+    private static RemotePathMapping Mapping(string host, string remotePath, string localPath)
+        => new() { Host = host, RemotePath = remotePath, LocalPath = localPath };
+
+    [Fact]
+    public async Task Returns_path_unchanged_when_no_mappings_exist()
+    {
+        using var db = CreateDb();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/home/user/downloads/file.mkv");
+
+        result.Should().Be("/home/user/downloads/file.mkv");
+    }
+
+    [Fact]
+    public async Task Returns_path_unchanged_when_no_mapping_matches_the_host()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("other-box", "/downloads", "/data/downloads"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/downloads/file.mkv");
+
+        result.Should().Be("/downloads/file.mkv");
+    }
+
+    [Fact]
+    public async Task Remaps_a_file_under_the_mapped_remote_path()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/home/user/downloads", "/data/seedbox"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/home/user/downloads/race/file.mkv");
+
+        result.Should().Be("/data/seedbox/race/file.mkv");
+    }
+
+    [Fact]
+    public async Task Matches_the_host_case_insensitively()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("SeedBox", "/downloads", "/data/seedbox"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/downloads/file.mkv");
+
+        result.Should().Be("/data/seedbox/file.mkv");
+    }
+
+    [Fact]
+    public async Task Exact_match_returns_the_local_base_path()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/downloads", "/data/seedbox"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/downloads");
+
+        result.Should().Be("/data/seedbox");
+    }
+
+    [Fact]
+    public async Task Tolerates_trailing_slashes_on_both_the_mapping_and_the_input()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/downloads/", "/data/seedbox/"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/downloads/file.mkv/");
+
+        result.Should().Be("/data/seedbox/file.mkv");
+    }
+
+    [Fact]
+    public async Task Longest_remote_prefix_wins_when_mappings_nest()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/downloads", "/data/general"));
+        db.RemotePathMappings.Add(Mapping("seedbox", "/downloads/sports", "/data/sports"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/downloads/sports/file.mkv");
+
+        result.Should().Be("/data/sports/file.mkv");
+    }
+
+    [Fact]
+    public async Task Does_not_match_across_path_segment_boundaries()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/data", "/local/data"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "/database/file.mkv");
+
+        result.Should().Be("/database/file.mkv");
+    }
+
+    [Fact]
+    public async Task Translates_windows_style_remote_paths()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("winbox", @"C:\Downloads", "/data/downloads"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("winbox", @"C:\Downloads\race\file.mkv");
+
+        result.Should().Be(Path.Combine("/data/downloads", "race", "file.mkv"));
+    }
+
+    [Fact]
+    public async Task Returns_empty_path_unchanged()
+    {
+        using var db = CreateDb();
+        db.RemotePathMappings.Add(Mapping("seedbox", "/downloads", "/data/seedbox"));
+        await db.SaveChangesAsync();
+        var service = CreateService(db);
+
+        var result = await service.RemapRemoteToLocalAsync("seedbox", "");
+
+        result.Should().Be("");
+    }
+}


### PR DESCRIPTION
## Problem

The Enhanced Download Monitor used the raw `download.FilePath` reported by the download client (e.g. rTorrent on a seedbox) when scanning externally-added completed downloads. For remote clients, paths like `/home/nicholos/data/...` don't exist inside the Sportarr container, so the scan folder was never found and the download was never auto-imported.

## Change

- Add a shared `IRemotePathMappingService` / `RemotePathMappingService` that mirrors Sonarr's `RemotePathMappingService`.
- Register it as a scoped service in `AddSportarrCoreServices`.
- Update `EnhancedDownloadMonitorService` to translate `download.FilePath` through the mapping before checking existence.
- Remove the duplicated `TranslatePathAsync` implementations from `FileImportService`, `ImportService`, and `ProvideImportItemService`, pointing them at the shared service instead.

## Verification

- `dotnet build src/Sportarr.csproj` passes.
- `Sportarr.Api.Tests`: 880 passed, 0 failed.
- Built and deployed the fix to a k3s cluster; external downloads from a seedbox rTorrent client now import correctly with a configured RemotePathMapping.

Fixes imports from remote download clients when the file path reported by the client differs from the local container path.