### PR TITLE
Stop a leading season year from straddling into the release date

### DIFF
--- a/src/Services/SportsFileNameParser.cs
+++ b/src/Services/SportsFileNameParser.cs
@@ -459,7 +459,24 @@ public class SportsFileNameParser
     };
 
     // Date extraction patterns
-    private static readonly Regex DatePattern = new(@"(?<year>\d{4})[\.\-\s]+(?<month>\d{2})[\.\-\s]+(?<day>\d{2})", RegexOptions.Compiled);
+    // The separator run is captured once and back-referenced, so all three fields
+    // must be joined by the SAME separator. Without that, the class matched
+    // independently at each position and a title carrying both a season year and a
+    // date -- "MLB_2026__05.08.2026__Red_Sox_vs_Athletics", which CleanFilename
+    // turns into "MLB 2026  05.08.2026  ..." -- anchored on the LEADING SEASON YEAR
+    // ("2026" + "  ") and then consumed "05" and "08" out of the real date.
+    //
+    // When the stolen pair was day-first with a day of 13-31 the resulting
+    // DateTime threw and the swap-retry below recovered it, so that half looked
+    // fine. When the day was 1-12 it produced a VALID BUT WRONG date -- 5 Aug read
+    // as 8 May -- and returned it silently, with no exception and no log line at
+    // any level. A wrong date is worse than no date here: it drives the +/-3-day
+    // hard rejection in ReleaseMatchingService, so the correct release gets
+    // rejected for its own event and the event stays missing.
+    //
+    // Requiring separator consistency makes that match impossible, and the
+    // DayFirstDatePattern fallback below then reads "05.08.2026" correctly.
+    private static readonly Regex DatePattern = new(@"(?<!\d)(?<year>\d{4})(?<sep>[\.\-\s]+)(?<month>\d{2})\k<sep>(?<day>\d{2})(?!\d)", RegexOptions.Compiled);
     // European day-first dating ("Spain vs Argentina 19.07.2026"). Only
     // consulted when the year-first pattern found nothing; the lookarounds
     // keep the two-digit groups from binding inside longer digit runs.

--- a/tests/Sportarr.Api.Tests/Services/SeasonYearDateStraddleTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/SeasonYearDateStraddleTests.cs
@@ -1,0 +1,75 @@
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Regression: DatePattern let its separator class match independently at each
+/// position, so a title carrying BOTH a season year and a date --
+/// "MLB_2026__05.08.2026__..." , which CleanFilename turns into
+/// "MLB 2026  05.08.2026  ..." -- anchored on the leading SEASON YEAR and then
+/// consumed the day/month of the real date that followed it.
+///
+/// The visible half was already handled: when the stolen pair was day-first with a
+/// day of 13-31, new DateTime(2026, 29, 7) threw and the swap-retry recovered it.
+///
+/// The silent half was not. With a day of 1-12 the straddle produced a VALID but
+/// WRONG date -- 5 Aug 2026 read as 8 May 2026 -- returned with no exception and no
+/// log line at any level. That is the damaging case: EventDate feeds the +/-3-day
+/// hard rejection in ReleaseMatchingService, so an ~89-day error makes the CORRECT
+/// release get hard-rejected for its own event, and the event stays missing with
+/// nothing in the logs to explain why.
+/// </summary>
+public class SeasonYearDateStraddleTests
+{
+    private static SportsFileNameParser NewParser() =>
+        new(new Mock<ILogger<SportsFileNameParser>>().Object);
+
+    [Theory]
+    // The silent half -- day <= 12. These returned a wrong date before the fix.
+    [InlineData("MLB_2026__05.08.2026__Boston_Red_Sox_vs_Athletics_1080p60fps_NESN", 2026, 8, 5)]
+    [InlineData("MLB_2026__01.02.2026__Chicago_Cubs_vs_St._Louis_Cardinals_1080p60fps_MARQ", 2026, 2, 1)]
+    [InlineData("MLB_2026__11.08.2026__Texas_Rangers_vs_Houston_Astros_1080p60fps_ATV", 2026, 8, 11)]
+    [InlineData("MLB_2026__12.08.2026__New_York_Yankees_vs_Chicago_Cubs_1080p60fps_YES", 2026, 8, 12)]
+    // The loud half -- day >= 13. Already recovered by the swap-retry; pinned so the
+    // separator change does not regress it.
+    [InlineData("MLB_2026__29.07.2026__Milwaukee_Brewers_vs_San_Francisco_Giants_1080p60fps_BREW", 2026, 7, 29)]
+    [InlineData("MLB_2026__31.07.2026__Washington_Nationals_vs_Atlanta_Braves_1080p60fps_NATS", 2026, 7, 31)]
+    public void SeasonYearPrefix_DoesNotStraddleIntoTheRealDate(string title, int y, int m, int d)
+    {
+        NewParser().Parse(title).EventDate.Should().Be(new DateTime(y, m, d));
+    }
+
+    [Theory]
+    // Year-first with a consistent separator must keep working unchanged.
+    [InlineData("Formula1.2026.07.26.Belgian.GP.Qualifying.1080p.F1TV", 2026, 7, 26)]
+    [InlineData("NBA_Today_2026_30_07_720pEN60fps_ESPN", 2026, 7, 30)]
+    [InlineData("NFL_Live_2026_31_07_720pEN60fps_ESPN", 2026, 7, 31)]
+    // Underscore-separated fields collapse to a repeated space run; the
+    // back-reference must accept that run as long as it is consistent.
+    [InlineData("Sport_2026__07__26__Something_1080p", 2026, 7, 26)]
+    public void ConsistentlySeparatedDates_StillParse(string title, int y, int m, int d)
+    {
+        NewParser().Parse(title).EventDate.Should().Be(new DateTime(y, m, d));
+    }
+
+    [Fact]
+    public void RealDateWins_WhenSeasonYearAndIsoDateBothPresent()
+    {
+        NewParser().Parse("MLB_2026__2026.08.05__Boston_Red_Sox_vs_Athletics_1080p")
+            .EventDate.Should().Be(new DateTime(2026, 8, 5));
+    }
+
+    [Theory]
+    // Titles with no date must not gain one -- the year-only and SyyyyExx
+    // fallbacks only run when no date was extracted.
+    [InlineData("Formula1.2026.Monaco.Grand.Prix.1080p.WEB.h264-BILLIE")]
+    [InlineData("Formula1.2026.Round13.Hungarian.Grand.Prix.Race.SkyF1HD.1080p.x264")]
+    public void DatelessTitles_YieldNoDate(string title)
+    {
+        NewParser().Parse(title).EventDate.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## The bug

`DatePattern` let its separator class match independently at each position:

```csharp
new(@"(?<year>\d{4})[\.\-\s]+(?<month>\d{2})[\.\-\s]+(?<day>\d{2})", ...)
```

So a title carrying **both a season year and a date** straddles the two. `CleanFilename` turns
`MLB_2026__05.08.2026__Boston_Red_Sox_vs_Athletics_1080p60fps_NESN` into
`MLB 2026  05.08.2026  Boston ...`, and the regex anchors on the **leading season year**
(`2026` + `"  "`), then consumes `05` and `08` out of the real date that follows:

| matched span | year | month | day | result |
|---|---|---|---|---|
| `2026  05.08` | 2026 | 5 | 8 | `2026-05-08` |

The release is 5 August. The parser returns 8 May.

## Why the existing recovery doesn't catch it

When the stolen pair is day-first with a day of **13–31**, `new DateTime(2026, 29, 7)` throws and
the swap-retry in the `catch` recovers it — so that half looks healthy, and it's the only half that
shows up in logs (as `[WRN] [SportsFileNameParser] Invalid date 2026-29-7 in '...'`).

When the day is **1–12** the straddle produces a **valid but wrong** `DateTime`. No exception, so
the `catch` never runs; `DayFirstDatePattern` never runs either, because it lives in the `else` of
`if (dateMatch.Success)` and `DatePattern` *did* match. The wrong date is returned silently, with
no log line at any level.

That silent half is the damaging one. `EventDate` drives the ±3-day hard rejection in
`ReleaseMatchingService`:

```
result.Confidence -= 100;
result.IsHardRejection = true;
result.Rejections.Add($"Date mismatch: release is ..., event is ... ({daysDiff:F0} days off)");
```

An ~89-day error means the **correct** release is hard-rejected for its own event. The event stays
missing and nothing in the logs explains why. Roughly 12 of every 31 affected titles fail this way.

Simulating current `main` against real release titles:

| title | parsed | correct |
|---|---|---|
| `MLB_2026__29.07.2026__Milwaukee_Brewers_...` | 2026-07-29 | 2026-07-29 (recovered by swap-retry) |
| `NBA_Today_2026_30_07_720pEN60fps_ESPN` | 2026-07-30 | 2026-07-30 (recovered) |
| `MLB_2026__05.08.2026__Boston_Red_Sox_...` | **2026-05-08** | 2026-08-05 |
| `MLB_2026__01.02.2026__Chicago_Cubs_...` | **2026-01-02** | 2026-02-01 |
| `MLB_2026__11.08.2026__Texas_Rangers_...` | **2026-11-08** | 2026-08-11 |

## The fix

Capture the separator run once and back-reference it, so all three fields must be joined by the
**same** separator:

```csharp
new(@"(?<!\d)(?<year>\d{4})(?<sep>[\.\-\s]+)(?<month>\d{2})\k<sep>(?<day>\d{2})(?!\d)", ...)
```

`2026` + `"  "` + `05` + `"."` can no longer match as one date, so the straddle is impossible. The
existing `DayFirstDatePattern` fallback then reads `05.08.2026` correctly — **no new parsing path is
introduced**, and the `+` quantifier is kept so underscore-collapsed runs (`2026__07__26` ->
`2026  07  26`) still parse.

## Tests

`SeasonYearDateStraddleTests` covers the silent half, the loud half (so the separator change can't
regress the swap-retry), consistent-separator ISO and day-first forms, repeated-separator runs, a
title carrying both a season year and a real ISO date, and dateless titles that must not gain one.

Full suite: **921 passed, 0 failed.**
