### PR TITLE
Re-run npm ci when package-lock.json changes

### DIFF
--- a/src/Sportarr.csproj
+++ b/src/Sportarr.csproj
@@ -11,19 +11,40 @@
     <SkipFrontendBuild Condition="'$(SkipFrontendBuild)' == ''">false</SkipFrontendBuild>
   </PropertyGroup>
 
+  <!-- Restore frontend dependencies.
+       Incremental on the lockfile rather than on the mere presence of
+       node_modules. npm writes node_modules/.package-lock.json on every install
+       (npm 7+; this project already requires Node 20, i.e. npm 9+), so it is an
+       accurate record of what is actually installed. MSBuild skips this target
+       while that stamp is newer than package-lock.json, so warm rebuilds cost
+       nothing, but a changed lockfile — dependency bump, branch switch, rebase,
+       or simply pulling main — re-runs `npm ci` instead of being ignored.
+
+       Previously this was `Condition="... AND !Exists('../frontend/node_modules')"`,
+       which runs npm ci exactly once on a clean checkout and then never again,
+       while `npm run build` below still runs every time. The result was a build
+       that silently compiled the frontend against stale dependencies whenever the
+       lockfile moved, with no warning — defeating the reproducibility guarantee
+       that is the whole reason to use `npm ci` over `npm install`. -->
+  <Target Name="RestoreFrontend" Condition="'$(SkipFrontendBuild)' != 'true'"
+          Inputs="../frontend/package-lock.json"
+          Outputs="../frontend/node_modules/.package-lock.json">
+    <Exec Command="npm --version" ContinueOnError="true" StandardOutputImportance="Low">
+      <Output TaskParameter="ExitCode" PropertyName="NpmRestoreExitCode" />
+    </Exec>
+    <Exec Command="npm ci --quiet" WorkingDirectory="../frontend" Condition="'$(NpmRestoreExitCode)' == '0'" />
+  </Target>
+
   <!-- Automatic Frontend Build - runs before .NET build -->
   <!-- Builds React frontend and copies to wwwroot for serving -->
   <!-- Skip with: dotnet build -p:SkipFrontendBuild=true -->
-  <Target Name="BuildFrontend" BeforeTargets="Build;Publish" Condition="'$(SkipFrontendBuild)' != 'true'">
+  <Target Name="BuildFrontend" BeforeTargets="Build;Publish" DependsOnTargets="RestoreFrontend" Condition="'$(SkipFrontendBuild)' != 'true'">
     <Message Importance="High" Text="Building frontend..." />
 
     <!-- Check if npm is available -->
     <Exec Command="npm --version" ContinueOnError="true" StandardOutputImportance="Low">
       <Output TaskParameter="ExitCode" PropertyName="NpmExitCode" />
     </Exec>
-
-    <!-- Install frontend dependencies if node_modules doesn't exist -->
-    <Exec Command="npm ci --quiet" WorkingDirectory="../frontend" Condition="'$(NpmExitCode)' == '0' AND !Exists('../frontend/node_modules')" />
 
     <!-- Build frontend (outputs to _output/UI) -->
     <Exec Command="npm run build" WorkingDirectory="../frontend" Condition="'$(NpmExitCode)' == '0'" />


### PR DESCRIPTION
## The bug

`BuildFrontend` gates dependency installation on the **presence of the directory**:

```xml
<!-- Install frontend dependencies if node_modules doesn't exist -->
<Exec Command="npm ci --quiet" WorkingDirectory="../frontend"
      Condition="'$(NpmExitCode)' == '0' AND !Exists('../frontend/node_modules')" />

<!-- Build frontend (outputs to _output/UI) -->
<Exec Command="npm run build" WorkingDirectory="../frontend"
      Condition="'$(NpmExitCode)' == '0'" />
```

`npm ci` therefore runs **exactly once**, on a clean checkout, and never again — while
`npm run build` on the next line runs **unconditionally, every time**.

Once `node_modules` exists, any change to `package-lock.json` is silently ignored and the frontend
is compiled against whatever happens to already be on disk.

## Why it matters

This is not an edge case — it fires during ordinary work:

- bumping a dependency and rebuilding
- switching branches, or rebasing, between branches with different dependencies
- simply pulling `main`

There is no warning. The build succeeds, and produces an artifact that claims to be built from the
lockfile in the tree but isn't. Because the frontend is stitched into the same publish as the
backend, the shipped `wwwroot` can silently disagree with the committed lockfile.

It also defeats the specific guarantee that motivates `npm ci` over `npm install`: a clean,
lockfile-exact install. Running it once ever is close to not running it at all.

I hit this for real — checked out `main` on a tree whose `node_modules` was ~7 weeks stale, and the
build happily reused the old dependencies.

## The fix

Move the install into its own target that is incremental **on the lockfile** rather than on
directory presence:

```xml
<Target Name="RestoreFrontend" Condition="'$(SkipFrontendBuild)' != 'true'"
        Inputs="../frontend/package-lock.json"
        Outputs="../frontend/node_modules/.package-lock.json">
  ...
  <Exec Command="npm ci --quiet" WorkingDirectory="../frontend" Condition="'$(NpmRestoreExitCode)' == '0'" />
</Target>
```

`BuildFrontend` picks it up via `DependsOnTargets="RestoreFrontend"`.

npm writes `node_modules/.package-lock.json` on every install (npm 7+, and this project already
requires Node 20 → npm 9+), so it is an accurate record of what is actually installed — better than
a hand-rolled stamp, since it survives `dotnet clean` and reflects reality rather than build history.

MSBuild skips the target while that stamp is newer than `package-lock.json`, so **warm rebuilds are
unaffected** — which is presumably what the original `!Exists(...)` guard was protecting. The
missing-stamp case (clean checkout) is naturally treated as out-of-date, so first-run behaviour is
unchanged.

## Verification

On a checkout whose lockfile had moved:

| scenario | result |
|---|---|
| lockfile newer than stamp | `npm ci` runs |
| immediate rebuild | `Skipping target "RestoreFrontend" because all output files are up-to-date with respect to the input files` |
| `touch package-lock.json` | `npm ci` runs again |
| full `-t:BuildFrontend` chain | `Frontend build complete.`, 0 errors |

No behaviour change for CI, which already passes `-p:SkipFrontendBuild=true` to the publish steps
and builds the frontend separately.
