### PR TITLE
Apply the league-identity gate on the import side too

### DIFF
--- a/src/Services/LibraryImportService.cs
+++ b/src/Services/LibraryImportService.cs
@@ -1330,6 +1330,43 @@ public class LibraryImportService
             return 0;
         }
 
+        // ── LEAGUE IDENTITY GATE ────────────────────────────────────────────────
+        // The series-label gate above only fires for library-format filenames,
+        // which name their series ahead of the SxxxxExx token. A raw scene
+        // filename — "BSB.2026.Round06.Oulton.Park.International.Race.One…" —
+        // has no label, so that gate is skipped and nothing else in this method
+        // establishes WHICH series the file belongs to: round, session and year
+        // all agree across every series running the same weekend format.
+        //
+        // ValidateRelease rejects this on the grab side. The import side did not,
+        // so a cross-series file that reached disk by any route (manual copy, a
+        // grab made before the grab-side gate existed, a hardlinked leftover)
+        // could still be matched onto the wrong event and rename itself into the
+        // library. Reuse the same helper so the two sides cannot drift.
+        //
+        // Team sports are exempt: their filenames name the teams rather than the
+        // league ("Lakers.vs.Celtics.2026.03.05" never says "NBA"), and the team
+        // names are themselves the identity signal, checked separately below.
+        //
+        // A caller that already resolved the organization is also exempt: callers
+        // pass searchTitle as either a raw filename OR an already-parsed short
+        // title ("Spain Qualifying"), and the latter legitimately carries no
+        // league name. When organization was resolved and agrees with the league,
+        // identity is established and the title does not need to repeat it.
+        bool organizationEstablishesIdentity =
+            !string.IsNullOrWhiteSpace(organization) && evt.League != null &&
+            ReleaseMatchingService.SeriesLabelMatchesLeague(organization, evt.League);
+
+        if (string.IsNullOrWhiteSpace(seriesLabel) && evt.League != null &&
+            !organizationEstablishesIdentity &&
+            string.IsNullOrWhiteSpace(evt.HomeTeamName) && string.IsNullOrWhiteSpace(evt.AwayTeamName) &&
+            !ReleaseMatchingService.TitleHasLeagueIdentity(searchTitle, eventTitle, evt.League))
+        {
+            logger?.LogDebug("[Match] League identity gate: '{Title}' names neither league '{League}' nor anything distinctive from event '{Event}' - rejecting",
+                searchTitle, evt.League.Name, eventTitle);
+            return 0;
+        }
+
         // ── SPORT GATE ──────────────────────────────────────────────────────────
         // When the filename parser identified the sport, an event from a
         // different sport can never be the right match, no matter how the

--- a/src/Services/ReleaseMatchingService.cs
+++ b/src/Services/ReleaseMatchingService.cs
@@ -990,16 +990,12 @@ public class ReleaseMatchingService
             bool hasIdentityReason = result.MatchReasons.Any(r =>
                 identityReasons.Any(w => r.StartsWith(w, StringComparison.OrdinalIgnoreCase)));
 
-            // Distinctive event words: the event title minus format words
-            // shared across whole sports ("Race", "Qualifying", "Grand
-            // Prix"). What survives ("Chinese", "Hangtown", team names)
-            // actually identifies the event.
-            bool sharesDistinctiveWord = ExtractSignificantWords(normalizedEvent)
-                .Where(w => !w.All(char.IsDigit) && !GenericEventWords.Contains(w))
-                .Any(w => ContainsWholeWord(normalizedRelease, w));
-
-            if (!hasIdentityReason && !sharesDistinctiveWord &&
-                !TitleNamesLeague(release.Title, evt.League))
+            // Identity comes from the league's name/alias in the title or the
+            // event's own distinctive words. Shared with the import-side gate in
+            // LibraryImportService.CalculateMatchConfidence via
+            // TitleHasLeagueIdentity so the two cannot drift apart.
+            if (!hasIdentityReason &&
+                !TitleHasLeagueIdentity(release.Title, evt.Title, evt.League))
             {
                 result.Confidence -= 100;
                 result.IsHardRejection = true;
@@ -1303,7 +1299,7 @@ public class ReleaseMatchingService
     /// Extract significant words (excluding stop words) from a title
     /// Normalizes word numbers to digits for proper matching (Three -> 3)
     /// </summary>
-    private HashSet<string> ExtractSignificantWords(string title)
+    private static HashSet<string> ExtractSignificantWords(string title)
     {
         // First convert word numbers to digits
         var normalizedTitle = ConvertWordNumbersToDigits(title);
@@ -1422,6 +1418,32 @@ public class ReleaseMatchingService
     /// number means nothing across leagues (every motorsport league has an
     /// episode 19).
     /// </summary>
+    /// <summary>
+    /// True when <paramref name="title"/> carries identity for an event in
+    /// <paramref name="league"/> — i.e. it either names the league (or one of its
+    /// aliases) or shares a distinctive word with the event's own title.
+    ///
+    /// Distinctive words are the event title minus format words shared across
+    /// whole sports ("Race", "Qualifying", "Grand Prix"). What survives
+    /// ("Chinese", "Hangtown", team names) actually identifies the event, whereas
+    /// round / session / year agreement are SLOT signals — every series running
+    /// the same weekend format has a Round 2 Race in 2026.
+    ///
+    /// Shared by the grab-side gate in ValidateRelease and the import-side gate in
+    /// LibraryImportService.CalculateMatchConfidence so the two cannot drift apart.
+    /// </summary>
+    public static bool TitleHasLeagueIdentity(string title, string eventTitle, League league)
+    {
+        if (string.IsNullOrWhiteSpace(title) || league == null) return false;
+        if (TitleNamesLeague(title, league)) return true;
+        if (string.IsNullOrWhiteSpace(eventTitle)) return false;
+
+        var normalizedTitle = NormalizeTitle(title);
+        return ExtractSignificantWords(NormalizeTitle(eventTitle))
+            .Where(w => !w.All(char.IsDigit) && !GenericEventWords.Contains(w))
+            .Any(w => ContainsWholeWord(normalizedTitle, w));
+    }
+
     public static bool SeriesLabelMatchesLeague(string seriesLabel, League league)
     {
         if (string.IsNullOrWhiteSpace(seriesLabel) || league == null) return false;

--- a/tests/Sportarr.Api.Tests/Services/ImportLeagueIdentityTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/ImportLeagueIdentityTests.cs
@@ -1,0 +1,116 @@
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// Regression: the import side had no league-identity check for scene-style filenames.
+///
+/// LibraryImportService.CalculateMatchConfidence gated on SeriesLabelMatchesLeague, but the
+/// series label is only present in library-format names ("V8 Supercars - S2026E19 - …"). A raw
+/// scene name — "BSB.2026.Round06.Oulton.Park.International.Race.One…" — yields no label, so that
+/// gate was skipped and nothing else established WHICH series the file belonged to: round, session
+/// and year agree across every series running the same weekend format.
+///
+/// The grab side already rejected this (a British Superbike round was otherwise matched onto the
+/// F1 Monaco GP, same Round 6, and imported over the correct file as a "quality upgrade"). These
+/// pin the equivalent gate on the import side, and pin the shared helper both sides now use so
+/// they cannot drift apart.
+/// </summary>
+public class ImportLeagueIdentityTests
+{
+    private static League F1() => new() { Id = 2, Name = "Formula 1", Sport = "Motorsport" };
+
+    private static Event MonacoRace() => new()
+    {
+        Id = 1788,
+        Title = "Monaco Grand Prix - Race",
+        Sport = "Motorsport",
+        Round = "6",
+        Season = "2026",
+        EventDate = new DateTime(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc),
+        League = F1(),
+        LeagueId = 2,
+    };
+
+    [Theory]
+    // The exact titles that were mis-imported as Monaco GP.
+    [InlineData("BSB.2026.Round06.Oulton.Park.International.Race.One.TNT.WEB-DL.1080p.H264.DDP5.1.English-MWR")]
+    [InlineData("BSB.2026.Round06.Oulton.Park.International.Qualifying.TNT.WEB-DL.1080p.H264.DDP5.1.English-MWR")]
+    // Same shape, other series that share F1 race weekends and round numbering.
+    [InlineData("PorscheSupercup.2026.Round06.La.Course.1080p.WEB-DL")]
+    [InlineData("DTM.2026.Round06.Race.One.1080p.WEB-DL")]
+    public void SceneFilenameNamingAnotherSeries_IsRejected(string filename)
+    {
+        LibraryImportService.CalculateMatchConfidence(
+            searchTitle: filename,
+            eventTitle: "Monaco Grand Prix - Race",
+            organization: null,
+            evt: MonacoRace(),
+            parsedDate: null,
+            parsedYear: 2026,
+            parsedRoundNumber: 6)
+        .Should().Be(0);
+    }
+
+    [Theory]
+    // Names the league outright.
+    [InlineData("Formula1.2026.Monaco.Grand.Prix.1080p.WEB.h264-BILLIE")]
+    [InlineData("Formula1.2026.Round06.Monaco.Race.F1TV.WEB-DL.1080p.h264.English-MWR")]
+    // Underscore-separated: NormalizeTitle collapses '_' so identity still resolves.
+    [InlineData("Formula_1_2026_Race_06_Monaco_Grand_Prix_Race_1080pEN50fps_F1TV")]
+    // Does not name the league, but shares the event's distinctive word ("Monaco").
+    [InlineData("Monaco.Grand.Prix.2026.Race.1080p.WEB-DL")]
+    public void GenuineF1File_IsNotRejectedByTheGate(string filename)
+    {
+        LibraryImportService.CalculateMatchConfidence(
+            searchTitle: filename,
+            eventTitle: "Monaco Grand Prix - Race",
+            organization: null,
+            evt: MonacoRace(),
+            parsedDate: null,
+            parsedYear: 2026,
+            parsedRoundNumber: 6)
+        .Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TeamSportEvent_IsExemptFromTheGate()
+    {
+        // Team-sport filenames name the teams, never the league, so the gate must not fire.
+        var evt = new Event
+        {
+            Id = 900,
+            Title = "Los Angeles Lakers vs Boston Celtics",
+            Sport = "Basketball",
+            EventDate = new DateTime(2026, 3, 5, 0, 0, 0, DateTimeKind.Utc),
+            League = new League { Id = 9, Name = "NBA", Sport = "Basketball" },
+            LeagueId = 9,
+            HomeTeamName = "Los Angeles Lakers",
+            AwayTeamName = "Boston Celtics",
+        };
+
+        LibraryImportService.CalculateMatchConfidence(
+            searchTitle: "Los.Angeles.Lakers.vs.Boston.Celtics.2026.03.05.1080p.WEB-DL",
+            eventTitle: evt.Title,
+            organization: null,
+            evt: evt,
+            parsedDate: new DateTime(2026, 3, 5),
+            parsedYear: 2026)
+        .Should().BeGreaterThan(0);
+    }
+
+    [Theory]
+    // The shared helper both gates now call.
+    [InlineData("BSB.2026.Round06.Oulton.Park.International.Race.One-MWR", false)]
+    [InlineData("Formula1.2026.Monaco.Grand.Prix.1080p.WEB.h264-BILLIE", true)]
+    [InlineData("Monaco.Grand.Prix.2026.Race.1080p", true)]   // distinctive word only
+    [InlineData("Round.06.Race.2026.1080p", false)]           // pure slot signals, no identity
+    public void TitleHasLeagueIdentity_MatchesTheGateDecision(string title, bool expected)
+    {
+        ReleaseMatchingService.TitleHasLeagueIdentity(title, "Monaco Grand Prix - Race", F1())
+            .Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## The gap

`ValidateRelease` has a league-identity gate: round, session and year agreement are **slot signals**
— every series running the same weekend format has a Round 2 Race in 2026 — so none of them says
*which* series a release belongs to. Identity has to come from the league name/alias or the event's
own distinctive words.

`LibraryImportService.CalculateMatchConfidence` has no equivalent. It gates on
`SeriesLabelMatchesLeague`:

```csharp
if (!string.IsNullOrWhiteSpace(seriesLabel) && evt.League != null &&
    !ReleaseMatchingService.SeriesLabelMatchesLeague(seriesLabel, evt.League))
{
    return 0;
}
```

but `seriesLabel` is the text ahead of an `SxxxxExx` token, so it only exists for library-format
names (`"V8 Supercars - S2026E19 - …"`). A raw scene name —
`BSB.2026.Round06.Oulton.Park.International.Race.One.TNT.WEB-DL.1080p.H264.DDP5.1.English-MWR` —
yields no label, the gate is skipped, and nothing else in the method establishes the series. A
British Superbike round then scores against an F1 Round 6 event on round + session + year alone.

## Why it matters even with the grab-side gate in place

Any file reaching the import path without having passed `ValidateRelease` is unprotected: a manual
copy into the drop folder, a hardlinked leftover, or a grab made before the grab-side gate existed.

I hit the last case. A BSB round was matched onto the F1 Monaco GP (same Round 6, same
"Qualifying"/"Race" session, same year), imported as a *quality upgrade*, and **renamed over the
correct file** — surfacing only as `[INF] [RSS Sync] 🔄 Quality upgrade grabbed`, which reads as
success.

## The change

Extract the shared decision into `ReleaseMatchingService.TitleHasLeagueIdentity(title, eventTitle,
league)` — true when the title names the league (or an alias) **or** shares a distinctive word with
the event title — and call it from **both** gates, so they cannot drift apart. The grab-side block
is refactored onto it rather than duplicated.

`ExtractSignificantWords` becomes `static`; it never used instance state.

Two exemptions, both required by existing callers and both covered by tests:

- **Team sports.** Their filenames name the teams, not the league —
  `Lakers.vs.Celtics.2026.03.05` never says "NBA" — and the team names are themselves the identity
  signal, checked separately.
- **A caller that already resolved the organization.** `searchTitle` is sometimes a raw filename and
  sometimes an already-parsed short title (`"Spain Qualifying"`), and the latter legitimately
  carries no league name. When `organization` agrees with the league, identity is established and
  the title need not repeat it. (Without this exemption the existing
  `LibraryImportRoundMatchingTests` correctly fail — they exercise exactly that call shape.)

## Tests

`ImportLeagueIdentityTests` covers the rejection (the two real BSB titles plus Porsche Supercup and
DTM against the F1 Monaco event), the non-rejection of genuine F1 files (league named outright,
underscore-separated, and identified only by the distinctive word "Monaco"), the team-sport
exemption, and the shared helper's decisions directly.

**921 passed, 0 failed** (13 new).
