### PR TITLE
fix: normalize imported download state

### DIFF
--- a/src/Services/EnhancedDownloadMonitorService.cs
+++ b/src/Services/EnhancedDownloadMonitorService.cs
@@ -733,9 +733,6 @@ public class EnhancedDownloadMonitorService : BackgroundService
                 return;
             }
 
-            download.Status = DownloadStatus.Imported;
-            download.ImportedAt = DateTime.UtcNow;
-
             _logger.LogInformation("[Enhanced Download Monitor] ✓ Import successful: {Title}", download.Title);
 
             // Remove from download client if configured in the client's settings

--- a/src/Services/FileImportService.cs
+++ b/src/Services/FileImportService.cs
@@ -98,6 +98,22 @@ public class FileImportService : IFileImportService
 
     private static readonly string[] VideoExtensions = SupportedExtensions.Video;
 
+    internal static void MarkDownloadImported(DownloadQueueItem download, DateTime importedAt)
+    {
+        download.Status = DownloadStatus.Imported;
+        download.Progress = 100;
+        if (download.Size > 0)
+        {
+            download.Downloaded = Math.Max(download.Downloaded, download.Size);
+        }
+
+        download.TimeRemaining = null;
+        download.CompletedAt ??= importedAt;
+        download.ImportedAt = importedAt;
+        download.LastUpdate = importedAt;
+        download.ErrorMessage = null;
+    }
+
     public FileImportService(
         SportarrDbContext db,
         MediaFileParser parser,
@@ -650,9 +666,9 @@ public class FileImportService : IFileImportService
 
             _db.ImportHistories.Add(history);
 
-            // Update download status
-            download.Status = DownloadStatus.Imported;
-            download.ImportedAt = DateTime.UtcNow;
+            // Imported queue items are no longer polled, so normalize every
+            // derived transfer field while the successful import is committed.
+            MarkDownloadImported(download, history.ImportedAt);
 
             // Create EventFile record
             // IMPORTANT: Use quality/codec/source from download queue item (parsed from original release title at grab time)

--- a/tests/Sportarr.Api.Tests/Services/FileImportServiceTerminalStateTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/FileImportServiceTerminalStateTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+
+namespace Sportarr.Api.Tests.Services;
+
+public class FileImportServiceTerminalStateTests
+{
+    [Fact]
+    public void MarkDownloadImported_NormalizesStaleTransferState()
+    {
+        var importedAt = new DateTime(2026, 8, 19, 12, 30, 0, DateTimeKind.Utc);
+        var download = NewDownload(size: 1_000, downloaded: 350);
+        download.Status = DownloadStatus.Importing;
+        download.Progress = 35;
+        download.TimeRemaining = TimeSpan.FromMinutes(20);
+        download.ErrorMessage = "stale downloader error";
+        download.LastUpdate = importedAt.AddMinutes(-5);
+
+        FileImportService.MarkDownloadImported(download, importedAt);
+
+        download.Status.Should().Be(DownloadStatus.Imported);
+        download.Progress.Should().Be(100);
+        download.Downloaded.Should().Be(1_000);
+        download.TimeRemaining.Should().BeNull();
+        download.CompletedAt.Should().Be(importedAt);
+        download.ImportedAt.Should().Be(importedAt);
+        download.LastUpdate.Should().Be(importedAt);
+        download.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarkDownloadImported_PreservesExistingCompletedAt()
+    {
+        var completedAt = new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc);
+        var importedAt = completedAt.AddMinutes(30);
+        var download = NewDownload(size: 1_000, downloaded: 1_000);
+        download.CompletedAt = completedAt;
+
+        FileImportService.MarkDownloadImported(download, importedAt);
+
+        download.CompletedAt.Should().Be(completedAt);
+        download.ImportedAt.Should().Be(importedAt);
+    }
+
+    [Fact]
+    public void MarkDownloadImported_DoesNotReduceDownloadedBytes()
+    {
+        var download = NewDownload(size: 1_000, downloaded: 1_050);
+
+        FileImportService.MarkDownloadImported(download, DateTime.UtcNow);
+
+        download.Downloaded.Should().Be(1_050);
+    }
+
+    [Fact]
+    public void MarkDownloadImported_DoesNotInventBytesWhenSizeIsUnknown()
+    {
+        var download = NewDownload(size: 0, downloaded: 0);
+
+        FileImportService.MarkDownloadImported(download, DateTime.UtcNow);
+
+        download.Downloaded.Should().Be(0);
+        download.Progress.Should().Be(100);
+    }
+
+    private static DownloadQueueItem NewDownload(long size, long downloaded) => new()
+    {
+        Title = "Example release",
+        DownloadId = "example-download-id",
+        Size = size,
+        Downloaded = downloaded,
+    };
+}


### PR DESCRIPTION
## Summary

- normalize queue progress, byte counts, ETA, timestamps, and stale errors after a successful import
- preserve an existing completion timestamp and never reduce downloader-reported bytes
- keep terminal-state ownership in the import service and add focused regression tests

## Root cause

Imported queue items are excluded from subsequent download-client polling. The import path previously persisted only `Status` and `ImportedAt`, so values from the final in-progress poll could remain visible indefinitely even though the file had imported successfully.

The successful import path now commits a coherent terminal state using the import-history timestamp. The enhanced download monitor no longer overwrites that state after the import service returns.

## Validation

- `dotnet build src/Sportarr.csproj -p:SkipFrontendBuild=true`
- `dotnet test tests/Sportarr.Api.Tests/Sportarr.Api.Tests.csproj -p:SkipFrontendBuild=true` — 1,265 passed

I found the individual CLA but no automated signing flow. I am happy to complete whatever acknowledgment the project requires.
