### PR TITLE
fix: recover pooled sqlite connections after I/O errors

### DIFF
--- a/src/Data/SqliteIoErrorRecoveryInterceptor.cs
+++ b/src/Data/SqliteIoErrorRecoveryInterceptor.cs
@@ -1,0 +1,123 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Sportarr.Api.Data;
+
+/// <summary>
+/// Discards pooled SQLite connections after an I/O error so later work can
+/// open a fresh native handle. The command that failed is never retried here:
+/// for writes, SQLite may already have committed part or all of the command.
+/// </summary>
+public sealed class SqliteIoErrorRecoveryInterceptor : DbCommandInterceptor
+{
+    private static readonly TimeSpan PoolClearCooldown = TimeSpan.FromSeconds(30);
+
+    private readonly ILogger<SqliteIoErrorRecoveryInterceptor> _logger;
+    private readonly Action _clearPools;
+    private readonly TimeProvider _timeProvider;
+    private long _lastPoolClearTimestamp = long.MinValue;
+
+    public SqliteIoErrorRecoveryInterceptor(ILogger<SqliteIoErrorRecoveryInterceptor> logger)
+        : this(logger, SqliteConnection.ClearAllPools, TimeProvider.System)
+    {
+    }
+
+    internal SqliteIoErrorRecoveryInterceptor(
+        ILogger<SqliteIoErrorRecoveryInterceptor> logger,
+        Action clearPools,
+        TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _clearPools = clearPools;
+        _timeProvider = timeProvider;
+    }
+
+    public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+    {
+        TryRecover(eventData.Exception);
+        base.CommandFailed(command, eventData);
+    }
+
+    public override Task CommandFailedAsync(
+        DbCommand command,
+        CommandErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        TryRecover(eventData.Exception);
+        return base.CommandFailedAsync(command, eventData, cancellationToken);
+    }
+
+    internal bool TryRecover(Exception exception)
+    {
+        if (!TryFindIoError(exception, out var sqliteException))
+            return false;
+
+        var nowTimestamp = _timeProvider.GetTimestamp();
+        while (true)
+        {
+            var previousTimestamp = Volatile.Read(ref _lastPoolClearTimestamp);
+            if (previousTimestamp != long.MinValue &&
+                _timeProvider.GetElapsedTime(previousTimestamp, nowTimestamp) < PoolClearCooldown)
+                return false;
+
+            if (Interlocked.CompareExchange(
+                    ref _lastPoolClearTimestamp,
+                    nowTimestamp,
+                    previousTimestamp) == previousTimestamp)
+                break;
+        }
+
+        try
+        {
+            _clearPools();
+        }
+        catch (Exception clearException)
+        {
+            // Pool cleanup is best-effort and must never replace the original
+            // command exception that EF Core is already propagating.
+            Interlocked.CompareExchange(ref _lastPoolClearTimestamp, long.MinValue, nowTimestamp);
+            TryLog(() => _logger.LogError(
+                    clearException,
+                    "[Database] Failed to clear pooled SQLite connections after I/O error {SqliteErrorCode} (extended {SqliteExtendedErrorCode})",
+                    sqliteException.SqliteErrorCode,
+                    sqliteException.SqliteExtendedErrorCode));
+            return true;
+        }
+
+        TryLog(() => _logger.LogWarning(
+                sqliteException,
+                "[Database] SQLite I/O error {SqliteErrorCode} (extended {SqliteExtendedErrorCode}); cleared pooled connections so newly opened connections use fresh handles",
+                sqliteException.SqliteErrorCode,
+                sqliteException.SqliteExtendedErrorCode));
+        return true;
+    }
+
+    private static void TryLog(Action log)
+    {
+        try
+        {
+            log();
+        }
+        catch
+        {
+            // Recovery is invoked while EF Core is already propagating the
+            // command failure. A logging provider must not replace it.
+        }
+    }
+
+    internal static bool TryFindIoError(Exception exception, out SqliteException sqliteException)
+    {
+        for (Exception? current = exception; current != null; current = current.InnerException)
+        {
+            if (current is SqliteException candidate && candidate.SqliteErrorCode == 10)
+            {
+                sqliteException = candidate;
+                return true;
+            }
+        }
+
+        sqliteException = null!;
+        return false;
+    }
+}

--- a/src/Startup/ServiceCollectionExtensions.cs
+++ b/src/Startup/ServiceCollectionExtensions.cs
@@ -531,6 +531,7 @@ public static class ServiceCollectionExtensions
         // SyncMetrics measured block (one AsyncLocal read otherwise), so it
         // is safe to attach to every context including the request path.
         var commandCounter = new Sportarr.Api.Data.CommandCountingInterceptor();
+        services.AddSingleton<SqliteIoErrorRecoveryInterceptor>();
         var dbSettings = DatabaseSettings.FromConfiguration(configuration);
 
         void ConfigureProvider(DbContextOptionsBuilder options)
@@ -560,10 +561,12 @@ public static class ServiceCollectionExtensions
             }
         }
 
-        services.AddDbContext<SportarrDbContext>(options =>
+        services.AddDbContext<SportarrDbContext>((serviceProvider, options) =>
         {
             ConfigureProvider(options);
-            options.AddInterceptors(commandCounter)
+            options.AddInterceptors(
+                       commandCounter,
+                       serviceProvider.GetRequiredService<SqliteIoErrorRecoveryInterceptor>())
                    .ConfigureWarnings(w => w
                        .Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.AmbientTransactionWarning)
                        .Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning)

--- a/tests/Sportarr.Api.Tests/Data/SqliteIoErrorRecoveryInterceptorTests.cs
+++ b/tests/Sportarr.Api.Tests/Data/SqliteIoErrorRecoveryInterceptorTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sportarr.Api.Data;
+using Sportarr.Api.Startup;
+
+namespace Sportarr.Api.Tests.Data;
+
+public class SqliteIoErrorRecoveryInterceptorTests
+{
+    private static SqliteIoErrorRecoveryInterceptor CreateInterceptor(
+        Action clearPools,
+        ILogger<SqliteIoErrorRecoveryInterceptor>? logger = null) =>
+        new(
+            logger ?? NullLogger<SqliteIoErrorRecoveryInterceptor>.Instance,
+            clearPools,
+            TimeProvider.System);
+
+    private sealed class ThrowingLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            throw new InvalidOperationException("logger failed");
+    }
+
+    [Fact]
+    public void TryFindIoError_FindsNestedSqliteIoErrorAndPreservesExtendedCode()
+    {
+        var sqliteException = new SqliteException("short read", 10, 522);
+        var exception = new DbUpdateException("save failed", sqliteException);
+
+        var found = SqliteIoErrorRecoveryInterceptor.TryFindIoError(exception, out var result);
+
+        found.Should().BeTrue();
+        result.Should().BeSameAs(sqliteException);
+        result.SqliteExtendedErrorCode.Should().Be(522);
+    }
+
+    [Fact]
+    public void TryRecover_NonIoErrorDoesNotClearPools()
+    {
+        var clearCount = 0;
+        var interceptor = CreateInterceptor(() => Interlocked.Increment(ref clearCount));
+
+        var recovered = interceptor.TryRecover(new SqliteException("busy", 5, 5));
+
+        recovered.Should().BeFalse();
+        clearCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryRecover_ConcurrentIoErrorsClearPoolsOnceWithinCooldown()
+    {
+        var clearCount = 0;
+        var interceptor = CreateInterceptor(() => Interlocked.Increment(ref clearCount));
+        var exception = new SqliteException("I/O error", 10, 4618);
+
+        Parallel.For(0, 64, _ => interceptor.TryRecover(exception));
+
+        clearCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryRecover_ClearAndLoggingFailuresDoNotEscape()
+    {
+        var interceptor = CreateInterceptor(
+            () => throw new InvalidOperationException("clear failed"),
+            new ThrowingLogger<SqliteIoErrorRecoveryInterceptor>());
+
+        var act = () => interceptor.TryRecover(new SqliteException("I/O error", 10, 10));
+
+        act.Should().NotThrow().Which.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryRecover_ClearFailureDoesNotConsumeCooldown()
+    {
+        var clearAttempts = 0;
+        var interceptor = CreateInterceptor(() =>
+        {
+            if (Interlocked.Increment(ref clearAttempts) == 1)
+                throw new InvalidOperationException("clear failed");
+        });
+        var exception = new SqliteException("I/O error", 10, 10);
+
+        interceptor.TryRecover(exception).Should().BeTrue();
+        interceptor.TryRecover(exception).Should().BeTrue();
+
+        clearAttempts.Should().Be(2);
+    }
+
+    [Fact]
+    public void TryRecover_SuccessfulClearWithLoggingFailureDoesNotEscape()
+    {
+        var interceptor = CreateInterceptor(
+            () => { },
+            new ThrowingLogger<SqliteIoErrorRecoveryInterceptor>());
+
+        var act = () => interceptor.TryRecover(new SqliteException("I/O error", 10, 10));
+
+        act.Should().NotThrow().Which.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddSportarrDatabase_AttachesOneSharedRecoveryInterceptorToBothContextPaths()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSportarrDatabase(
+            new ConfigurationBuilder().Build(),
+            Path.Combine(Path.GetTempPath(), $"sportarr-recovery-{Guid.NewGuid():N}.db"));
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        using var scopedContext = scope.ServiceProvider.GetRequiredService<SportarrDbContext>();
+        using var factoryContext = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<SportarrDbContext>>()
+            .CreateDbContext();
+
+        var registered = scope.ServiceProvider.GetRequiredService<SqliteIoErrorRecoveryInterceptor>();
+        GetRecoveryInterceptors(scopedContext).Should().ContainSingle().Which.Should().BeSameAs(registered);
+        GetRecoveryInterceptors(factoryContext).Should().ContainSingle().Which.Should().BeSameAs(registered);
+    }
+
+    private static List<SqliteIoErrorRecoveryInterceptor> GetRecoveryInterceptors(SportarrDbContext context) =>
+        context.GetService<IDbContextOptions>()
+            .Extensions
+            .OfType<CoreOptionsExtension>()
+            .SelectMany(extension => extension.Interceptors ?? Array.Empty<IInterceptor>())
+            .OfType<SqliteIoErrorRecoveryInterceptor>()
+            .ToList();
+}


### PR DESCRIPTION
## Summary

- detect SQLite primary I/O error code 10 from failed EF commands
- log the extended SQLite error code for useful diagnosis
- clear pooled SQLite connections once per cooldown so newly opened connections use fresh native handles
- deliberately do not retry the failed command because a write's commit state may be ambiguous
- attach one shared recovery interceptor to both scoped and factory-created contexts

## Rationale

A SQLite I/O failure can leave database operations failing across otherwise unrelated background services and requests until the Sportarr process restarts, even when the database remains intact and works after restart. The exact underlying I/O subcode is not currently logged, so this change is intentionally resilience and observability rather than a claim to fix a proven storage root cause.

Pool cleanup and diagnostic logging are best-effort and cannot replace the original EF/SQLite exception.

## Testing

- : 7 passed
- compilation of the complete backend test project succeeded
- broader backend run excluding the existing container-dependent  passed; the unfiltered SDK-container run failed only those two mount-resolution assertions