### PR TITLE
fix(sabnzbd): improve SAB-compatible client category handling

### DIFF
--- a/src/Services/DownloadClientService.cs
+++ b/src/Services/DownloadClientService.cs
@@ -520,6 +520,8 @@ public class DownloadClientService : IDownloadClientService
             {
                 DownloadClientType.QBittorrent => await FindQBittorrentDownloadByTitleAsync(config, title, category),
                 DownloadClientType.Decypharr => await FindDecypharrDownloadByTitleAsync(config, title, category),
+                DownloadClientType.Sabnzbd or DownloadClientType.NZBdav or DownloadClientType.DecypharrUsenet =>
+                    await FindSabnzbdDownloadByTitleAsync(config, title, category),
                 // DecypharrUsenet uses SABnzbd API which doesn't support title-based lookup
                 // Other clients can be added later - for now return null
                 _ => (null, null)
@@ -1449,6 +1451,13 @@ public class DownloadClientService : IDownloadClientService
     {
         var client = GetQBittorrentClient(config);
         return await client.FindTorrentByTitleAsync(config, title, category);
+    }
+
+    private async Task<(DownloadClientStatus? Status, string? NewDownloadId)> FindSabnzbdDownloadByTitleAsync(
+        DownloadClient config, string title, string category)
+    {
+        var client = GetSabnzbdClient(config);
+        return await client.FindDownloadByTitleAsync(config, title, category);
     }
 
     // Aria2 client methods

--- a/src/Services/SabnzbdClient.cs
+++ b/src/Services/SabnzbdClient.cs
@@ -252,6 +252,11 @@ public class SabnzbdClient
                 content.Add(new StringContent("addfile"), "mode");
                 content.Add(new StringContent("json"), "output");
                 content.Add(new StringContent(category), "cat");
+                // NZBdav and some SAB-compatible clients only honour category
+                // when it is also present in the query string and/or sent as
+                // "category" (not just SABnzbd's standard "cat").
+                if (!string.IsNullOrWhiteSpace(category))
+                    content.Add(new StringContent(category), "category");
 
                 if (!string.IsNullOrWhiteSpace(apiKey))
                     content.Add(new StringContent(apiKey), "apikey");
@@ -279,11 +284,21 @@ public class SabnzbdClient
             content.Add(fileContent, "nzbfile", filename);
 
             var requestUrl = $"{baseUrl}/api";
-            if (useQueryControlParams)
+            if (!useQueryControlParams && !string.IsNullOrWhiteSpace(category))
+            {
+                // Mirror cat in the query string without duplicating mode/output
+                // (CherryPy merges duplicated params into a list and SABnzbd
+                // crashes on it — see issues #183 and #263).
+                requestUrl += $"?cat={Uri.EscapeDataString(category)}&category={Uri.EscapeDataString(category)}";
+            }
+            else if (useQueryControlParams)
             {
                 var addFileQuery = new System.Text.StringBuilder("?mode=addfile&output=json");
                 if (!string.IsNullOrWhiteSpace(category))
+                {
                     addFileQuery.Append($"&cat={Uri.EscapeDataString(category)}");
+                    addFileQuery.Append($"&category={Uri.EscapeDataString(category)}");
+                }
                 if (!string.IsNullOrWhiteSpace(apiKey))
                     addFileQuery.Append($"&apikey={Uri.EscapeDataString(apiKey)}");
                 else if (!string.IsNullOrWhiteSpace(config.Username) && !string.IsNullOrWhiteSpace(config.Password))
@@ -685,7 +700,7 @@ public class SabnzbdClient
                     {
                         DownloadId = item.nzo_id,
                         Title = item.filename,
-                        Category = item.category,
+                        Category = item.CategoryName,
                         FilePath = "", // Queue items don't have a storage path yet
                         Size = (long)(sizeMb * 1024 * 1024),
                         IsCompleted = false,
@@ -702,7 +717,7 @@ public class SabnzbdClient
         if (history != null)
         {
             foreach (var item in history.Where(h =>
-                h.category.Equals(category, StringComparison.OrdinalIgnoreCase) &&
+                h.CategoryName.Equals(category, StringComparison.OrdinalIgnoreCase) &&
                 h.status.Equals("Completed", StringComparison.OrdinalIgnoreCase)))
             {
                 if (seenIds.Add(item.nzo_id))
@@ -711,7 +726,7 @@ public class SabnzbdClient
                     {
                         DownloadId = item.nzo_id,
                         Title = item.name,
-                        Category = item.category,
+                        Category = item.CategoryName,
                         FilePath = item.storage,
                         Size = item.bytes,
                         IsCompleted = true,
@@ -726,6 +741,50 @@ public class SabnzbdClient
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Find a download by release title in queue or history. Used when the
+    /// client changed or mis-filed the category (NZBdav/Decypharr quirk).
+    /// </summary>
+    public async Task<(DownloadClientStatus? Status, string? NewDownloadId)> FindDownloadByTitleAsync(
+        DownloadClient config, string title, string? expectedCategory)
+    {
+        try
+        {
+            var normalizedTitle = title.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedTitle))
+                return (null, null);
+
+            bool TitleMatches(string candidate) =>
+                !string.IsNullOrWhiteSpace(candidate) &&
+                (candidate.Equals(normalizedTitle, StringComparison.OrdinalIgnoreCase) ||
+                 candidate.StartsWith(normalizedTitle, StringComparison.OrdinalIgnoreCase) ||
+                 normalizedTitle.StartsWith(candidate, StringComparison.OrdinalIgnoreCase));
+
+            var queue = await GetQueueAsync(config);
+            var queueMatch = queue?.FirstOrDefault(q => TitleMatches(q.filename));
+            if (queueMatch != null)
+            {
+                var status = await GetDownloadStatusAsync(config, queueMatch.nzo_id, expectedCategory);
+                return status != null ? (status, queueMatch.nzo_id) : (null, null);
+            }
+
+            var history = await GetHistoryAsync(config);
+            var historyMatch = history?.FirstOrDefault(h => TitleMatches(h.name));
+            if (historyMatch != null)
+            {
+                var status = await GetDownloadStatusAsync(config, historyMatch.nzo_id, expectedCategory);
+                return status != null ? (status, historyMatch.nzo_id) : (null, null);
+            }
+
+            return (null, null);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[SABnzbd] Error finding download by title: {Title}", title);
+            return (null, null);
+        }
     }
 
     /// <summary>
@@ -855,10 +914,20 @@ public class SabnzbdClient
                 };
             }
 
+            var queueMatchedById = queueItem != null;
             if (queueItem != null && !string.IsNullOrWhiteSpace(categoryToMatch) &&
                 !string.Equals(queueItem.CategoryName, categoryToMatch, StringComparison.OrdinalIgnoreCase))
             {
-                queueItem = null;
+                if (queueMatchedById)
+                {
+                    _logger.LogWarning(
+                        "[SABnzbd] Download {NzoId} found in queue with category '{Actual}' (expected '{Expected}'); tracking by nzo_id anyway",
+                        nzoId, queueItem.CategoryName, categoryToMatch);
+                }
+                else
+                {
+                    queueItem = null;
+                }
             }
 
             if (queueItem != null)
@@ -925,9 +994,11 @@ public class SabnzbdClient
             var historyItem = history?.FirstOrDefault(h => string.Equals(h.nzo_id, nzoId, StringComparison.OrdinalIgnoreCase));
 
             if (historyItem != null && !string.IsNullOrWhiteSpace(categoryToMatch) &&
-                !string.Equals(historyItem.category, categoryToMatch, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(historyItem.CategoryName, categoryToMatch, StringComparison.OrdinalIgnoreCase))
             {
-                historyItem = null;
+                _logger.LogWarning(
+                    "[SABnzbd] Download {NzoId} found in history with category '{Actual}' (expected '{Expected}'); tracking by nzo_id anyway",
+                    nzoId, historyItem.CategoryName, categoryToMatch);
             }
 
             if (historyItem != null)
@@ -1279,6 +1350,8 @@ public class SabnzbdClient
             }
 
             var baseUrl = $"{protocol}://{config.Host}:{config.Port}{urlBase}/api";
+            if (!string.IsNullOrWhiteSpace(category))
+                baseUrl += $"?cat={Uri.EscapeDataString(category)}&category={Uri.EscapeDataString(category)}";
 
             // Build multipart form data for addfile request
             using var content = new MultipartFormDataContent();
@@ -1286,8 +1359,10 @@ public class SabnzbdClient
             // Add mode parameter
             content.Add(new StringContent("addfile"), "mode");
 
-            // Add category
+            // Add category — send both aliases for SAB-compatible clients.
             content.Add(new StringContent(category), "cat");
+            if (!string.IsNullOrWhiteSpace(category))
+                content.Add(new StringContent(category), "category");
 
             // Add output format
             content.Add(new StringContent("json"), "output");
@@ -1409,6 +1484,10 @@ public class SabnzbdClient
             // authenticate from there and reject form-only auth; real SABnzbd
             // accepts either.
             var addUrlQuery = new System.Text.StringBuilder("?mode=addurl&output=json");
+            // NZBdav reads the "category" alias from the query string; keep "cat"
+            // in the form body only so nothing is duplicated between the two.
+            if (!string.IsNullOrWhiteSpace(category))
+                addUrlQuery.Append($"&category={Uri.EscapeDataString(category)}");
             if (hasApiKey)
             {
                 addUrlQuery.Append($"&apikey={Uri.EscapeDataString(config.ApiKey!)}");
@@ -1598,8 +1677,14 @@ public class SabnzbdHistoryItem
     public string name { get; set; } = "";
     public string status { get; set; } = "";
     public long bytes { get; set; }
+    // SABnzbd history usually sends "category"; some SAB-compatible clients
+    // (including NZBdav queue snapshots) may send "cat" instead.
+    public string cat { get; set; } = "";
     public string category { get; set; } = "";
     public string storage { get; set; } = "";
     public long completed { get; set; } // Unix timestamp
     public string fail_message { get; set; } = ""; // Why it failed (if status is Failed)
+
+    [JsonIgnore]
+    public string CategoryName => !string.IsNullOrEmpty(category) ? category : cat;
 }

--- a/tests/Sportarr.Api.Tests/Services/SabnzbdCategoryMismatchTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/SabnzbdCategoryMismatchTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using Sportarr.Api.Services;
+using Sportarr.Api.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// When Sportarr polls by the nzo_id it received at grab time, a category
+/// mismatch means the client mis-filed the job (NZBdav/Decypharr quirk), not
+/// that another app owns the download. The status should still be returned.
+/// </summary>
+public class SabnzbdCategoryMismatchTests
+{
+    private sealed class HistoryMismatchHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var uri = request.RequestUri!.ToString();
+
+            if (uri.Contains("mode=queue"))
+            {
+                return Task.FromResult(Json("{\"queue\":{\"slots\":[]}}"));
+            }
+
+            if (uri.Contains("mode=history"))
+            {
+                return Task.FromResult(Json("""
+                {
+                    "history": {
+                        "slots": [{
+                            "nzo_id": "5ef134ef-4425-4044-a619-acb8dc9e6440",
+                            "name": "EPL.26-27-Matchday.1-Arsenal.FC.vs.Coventry.City.2160p.4K.UHD-SDX",
+                            "status": "Completed",
+                            "category": "uncategorized",
+                            "bytes": 16575673310,
+                            "storage": "/usenet/completed/uncategorized/EPL.26-27-Matchday.1-Arsenal.FC.vs.Coventry.City.2160p.4K.UHD-SDX"
+                        }]
+                    }
+                }
+                """));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body) };
+    }
+
+    [Fact]
+    public async Task GetDownloadStatus_StillReturnsCompleted_WhenCategoryWasMisFiled()
+    {
+        var client = new SabnzbdClient(
+            new HttpClient(new HistoryMismatchHandler()),
+            Mock.Of<ILogger<SabnzbdClient>>());
+        var config = new DownloadClient
+        {
+            Name = "NZBdav",
+            Type = DownloadClientType.Sabnzbd,
+            Host = "nzbdav",
+            Port = 3000,
+            ApiKey = "k3y",
+            Category = "sports"
+        };
+
+        var status = await client.GetDownloadStatusAsync(
+            config,
+            "5ef134ef-4425-4044-a619-acb8dc9e6440",
+            "sports");
+
+        status.Should().NotBeNull();
+        status!.Status.Should().Be("completed");
+        status.SavePath.Should().Contain("Coventry.City");
+    }
+
+    [Fact]
+    public async Task FindDownloadByTitle_ReturnsCompleted_WhenHistoryCategoryDiffers()
+    {
+        var client = new SabnzbdClient(
+            new HttpClient(new HistoryMismatchHandler()),
+            Mock.Of<ILogger<SabnzbdClient>>());
+        var config = new DownloadClient
+        {
+            Name = "NZBdav",
+            Type = DownloadClientType.Sabnzbd,
+            Host = "nzbdav",
+            Port = 3000,
+            ApiKey = "k3y",
+            Category = "sports"
+        };
+
+        var (status, downloadId) = await client.FindDownloadByTitleAsync(
+            config,
+            "EPL.26-27-Matchday.1-Arsenal.FC.vs.Coventry.City.2160p.4K.UHD-SDX",
+            "sports");
+
+        status.Should().NotBeNull();
+        downloadId.Should().Be("5ef134ef-4425-4044-a619-acb8dc9e6440");
+        status!.Status.Should().Be("completed");
+    }
+}

--- a/tests/Sportarr.Api.Tests/Services/SabnzbdHistoryCategoryTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/SabnzbdHistoryCategoryTests.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Sportarr.Api.Services;
+using FluentAssertions;
+
+namespace Sportarr.Api.Tests.Services;
+
+public class SabnzbdHistoryCategoryTests
+{
+    [Fact]
+    public void HistorySlot_BindsCategory_FromSabnzbdCategoryField()
+    {
+        var json = """
+        [{
+            "nzo_id": "5ef134ef-4425-4044-a619-acb8dc9e6440",
+            "name": "EPL.26-27-Matchday.1-Arsenal.FC.vs.Coventry.City.2160p.4K.UHD-SDX",
+            "status": "Completed",
+            "category": "uncategorized"
+        }]
+        """;
+
+        var items = JsonSerializer.Deserialize<List<SabnzbdHistoryItem>>(json);
+
+        items.Should().ContainSingle();
+        items![0].CategoryName.Should().Be("uncategorized");
+    }
+
+    [Fact]
+    public void HistorySlot_BindsCategory_FromSabnzbdCatField()
+    {
+        var json = """
+        [{
+            "nzo_id": "SABnzbd_nzo_abc123",
+            "name": "UFC.330.1080p.WEB.h264-SPORTY",
+            "status": "Completed",
+            "cat": "sports"
+        }]
+        """;
+
+        var items = JsonSerializer.Deserialize<List<SabnzbdHistoryItem>>(json);
+
+        items![0].CategoryName.Should().Be("sports");
+    }
+}

--- a/tests/Sportarr.Api.Tests/Services/SabnzbdNzbDavCategoryTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/SabnzbdNzbDavCategoryTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using Sportarr.Api.Services;
+using Sportarr.Api.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sportarr.Api.Tests.Services;
+
+/// <summary>
+/// NZBdav's SABnzbd emulator accepts category from the query string and/or a
+/// "category" alias, not only the standard multipart "cat" field.
+/// </summary>
+public class SabnzbdNzbDavCategoryTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Upload;
+        public string? UploadBody;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.Method == HttpMethod.Get && request.RequestUri!.AbsolutePath != "/api")
+            {
+                var nzb = "<?xml version=\"1.0\"?><nzb><file subject=\"x\">" + new string('x', 200) + "</file></nzb>";
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(nzb) };
+            }
+
+            Upload = request;
+            UploadBody = request.Content is not null ? await request.Content.ReadAsStringAsync(ct) : null;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"status\":true,\"nzo_ids\":[\"5ef134ef-4425-4044-a619-acb8dc9e6440\"]}")
+            };
+        }
+    }
+
+    [Fact]
+    public async Task AddFile_MirrorsCategoryInQueryStringAndFormAliases()
+    {
+        var handler = new CapturingHandler();
+        var client = new SabnzbdClient(new HttpClient(handler), Mock.Of<ILogger<SabnzbdClient>>());
+        var config = new DownloadClient { Name = "NZBdav", Type = DownloadClientType.Sabnzbd, Host = "nzbdav", Port = 3000, ApiKey = "k3y" };
+
+        var nzoId = await client.AddNzbAsync(config, "http://indexer/get/abc.nzb", "sports", "EPL.Match");
+
+        nzoId.Should().Be("5ef134ef-4425-4044-a619-acb8dc9e6440");
+        handler.Upload!.RequestUri!.Query.Should().Contain("cat=sports").And.Contain("category=sports");
+        handler.UploadBody.Should().Contain("name=cat").And.Contain("name=category");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a class of interoperability bugs between Sportarr's SABnzbd client and SAB-compatible download clients (including NZBdav) where category metadata is propagated or reported differently than standard SABnzbd.

**Problem**

- Some SAB-compatible clients ignore a multipart-only `cat` field and file completed jobs under a default/uncategorized category.
- Sportarr's download monitor then finds the job by explicit `nzo_id`, but discards it because the returned category does not match the grab category.
- Title-based fallback was not implemented for SAB clients, so the monitor gave up after repeated "not found" polls even though the completed media was present.

**Changes**

- Mirror `cat` and `category` on `addfile` uploads (query string + form aliases) without duplicating CherryPy-sensitive control params.
- Send the `category` alias on `addurl` via the query string while keeping `cat` in the form body.
- Bind both `cat` and `category` on `SabnzbdHistoryItem` via `CategoryName`.
- When polling by explicit `nzo_id`, keep tracking the download if the ID matches and log a category mismatch warning instead of treating it as missing.
- Wire SAB/NZBdav/DecypharrUsenet into `FindDownloadByTitleAsync` for monitor fallback.

## Test plan

- [x] `SabnzbdHistoryCategoryTests` — history deserializes `cat` vs `category`
- [x] `SabnzbdCategoryMismatchTests` — correct `nzo_id` + mismatched category still returns completed status; title fallback works
- [x] `SabnzbdNzbDavCategoryTests` — `addfile` sends both category aliases in query and form
- [x] Existing `SabnzbdAddUrlModeTests` still pass (no duplicated query/form params)
- [x] End-to-end validation on a live stack: Sportarr → NZBdav → STRM import → Jellyfin playback
