### PR TITLE
fix: preserve import warnings across download client polls

### DIFF
--- a/src/Services/EnhancedDownloadMonitorService.cs
+++ b/src/Services/EnhancedDownloadMonitorService.cs
@@ -475,6 +475,12 @@ public class EnhancedDownloadMonitorService : BackgroundService
         // Decypharr pauses torrents when complete since debrid services don't seed
         var isDecypharrCompleted = status.Status == "paused" && status.Progress >= 99.9;
 
+        if (download.Status == DownloadStatus.ImportWarning &&
+            status.Status is not ("failed" or "error"))
+        {
+            return;
+        }
+
         download.Status = status.Status switch
         {
             "downloading" => DownloadStatus.Downloading,

--- a/tests/Sportarr.Api.Tests/Services/DownloadMonitorImportWarningTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/DownloadMonitorImportWarningTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sportarr.Api.Data;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using Sportarr.Api.Services.Interfaces;
+
+namespace Sportarr.Api.Tests.Services;
+
+public class DownloadMonitorImportWarningTests
+{
+    [Theory]
+    [InlineData("Completed", true, true)]
+    [InlineData("Paused", true, true)]
+    [InlineData("Downloading", true, true)]
+    [InlineData("Queued", true, true)]
+    [InlineData("Completed", false, true)]
+    [InlineData("Completed", true, false)]
+    public async Task ClientPoll_PreservesImportWarningAcrossPollsAndReload(
+        string clientStatus, bool completedHandling, bool monitored)
+    {
+        var options = new DbContextOptionsBuilder<SportarrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options;
+        using var services = new ServiceCollection().BuildServiceProvider();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var config = new ConfigService(new ConfigurationBuilder().Build(),
+            NullLogger<ConfigService>.Instance);
+        using var handler = new CompletedDownloadHandler(clientStatus);
+        using var http = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(instance => instance.CreateClient(It.IsAny<string>())).Returns(http);
+        var clientService = new DownloadClientService(factory.Object, NullLoggerFactory.Instance,
+            NullLogger<DownloadClientService>.Instance, cache, config,
+            Mock.Of<IRemotePathMappingService>());
+
+        using (var db = new SportarrDbContext(options))
+        {
+            db.DownloadQueue.Add(new DownloadQueueItem
+            {
+                Title = "Formula.1.2026.Italy.Qualifying.1080p.WEB",
+                DownloadId = "test-download",
+                Status = DownloadStatus.ImportWarning,
+                ErrorMessage = "Not an upgrade",
+                ImportRetryCount = 0,
+                Added = DateTime.UtcNow.AddHours(-1),
+                OutputPath = "/downloads/original-path",
+                Event = new Event { Title = "Italian Grand Prix", Sport = "Motorsport", Monitored = monitored },
+                DownloadClient = new DownloadClient
+                {
+                    Name = "Fake SABnzbd", Type = DownloadClientType.Sabnzbd,
+                    Host = "localhost", Port = 8080, Category = "sportarr"
+                }
+            });
+            await db.SaveChangesAsync();
+        }
+
+        for (var poll = 0; poll < 3; poll++)
+        {
+            using var db = new SportarrDbContext(options);
+            using var monitor = new EnhancedDownloadMonitorService(services,
+                NullLogger<EnhancedDownloadMonitorService>.Instance);
+            var download = await db.DownloadQueue.Include(item => item.DownloadClient)
+                .Include(item => item.Event).SingleAsync();
+            var process = typeof(EnhancedDownloadMonitorService).GetMethod("ProcessDownloadAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            await (Task)process.Invoke(monitor, new object?[]
+            {
+                download, clientService, null, db, completedHandling, false, false, 0, CancellationToken.None
+            })!;
+            await db.SaveChangesAsync();
+
+            download.Status.Should().Be(DownloadStatus.ImportWarning);
+            download.ErrorMessage.Should().Be("Not an upgrade");
+            download.ImportRetryCount.Should().Be(0);
+            download.ImportedAt.Should().BeNull();
+            download.Progress.Should().Be(clientStatus == "Completed" ? 100 : 99);
+            download.OutputPath.Should().Be(clientStatus == "Completed"
+                ? "/downloads/test-download" : "/downloads/original-path");
+            (await db.Blocklist.CountAsync()).Should().Be(0);
+        }
+
+        handler.RequestCount.Should().BeGreaterThanOrEqualTo(3);
+
+        handler.Missing = true;
+        using (var db = new SportarrDbContext(options))
+        {
+            using var monitor = new EnhancedDownloadMonitorService(services,
+                NullLogger<EnhancedDownloadMonitorService>.Instance);
+            var download = await db.DownloadQueue.Include(item => item.DownloadClient).SingleAsync();
+            var process = typeof(EnhancedDownloadMonitorService).GetMethod("ProcessDownloadAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            await (Task)process.Invoke(monitor, new object?[]
+            {
+                download, clientService, null, db, completedHandling, false, false, 0, CancellationToken.None
+            })!;
+
+            download.MissingFromClientCount.Should().Be(1);
+            download.Status.Should().Be(DownloadStatus.ImportWarning);
+            (await db.DownloadQueue.CountAsync()).Should().Be(1);
+        }
+        handler.DeleteRequested.Should().BeFalse();
+    }
+
+    private sealed class CompletedDownloadHandler(string clientStatus) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public bool Missing { get; set; }
+        public bool DeleteRequested { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+                        DeleteRequested |= request.RequestUri!.Query.Contains("delete");
+            var json = request.RequestUri!.Query.Contains("mode=queue")
+                ? """{"queue":{"slots":[]}}"""
+                : Missing ? """{"history":{"slots":[]}}""" : JsonSerializer.Serialize(new
+                {
+                    history = new
+                    {
+                        slots = new[]
+                        {
+                            new
+                            {
+                                nzo_id = "test-download", name = "Formula.1.2026.Italy.Qualifying.1080p.WEB",
+                                status = clientStatus, category = "sportarr", bytes = 1000,
+                                storage = "/downloads/test-download"
+                            }
+                        }
+                    }
+                });
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Issue

A completed client job whose import is rejected as a non-upgrade remains in the
queue as `ImportWarning`. The next client poll maps the client's `completed`
status back to `Completed`, triggering the same import/ffprobe work again.

In the investigated instance, four Italian GP session downloads generated 424
import attempts, probes and equal-quality rejections over roughly 57 minutes.
This is observed repeated work, not an isolated before/after CPU benchmark.

## Fix

Preserve `ImportWarning` across non-failure client responses, after client metadata
refresh but before status remapping. Failed/error and missing-client reconciliation
still follow the existing paths. Explicit force-import and `ImportPending` are
unchanged. No quality rules, files, client entries or monitoring are modified.

Scope: six production lines in `EnhancedDownloadMonitorService` plus one regression
fixture. The fixture drives the real poll handler with fake SAB responses, reloads
persisted state/new monitor instances, and checks terminal/nonterminal responses,
disabled handling, unmonitored events and missing-client reconciliation.

## Validation

10/10 tests passed on this independent branch based on current `main` (`3cfbf7077`):

```sh
dotnet test tests/Sportarr.Api.Tests/Sportarr.Api.Tests.csproj -c Release -p:SkipFrontendBuild=true --filter 'FullyQualifiedName~DownloadMonitorImportWarningTests|FullyQualifiedName~FileImportServiceTerminalStateTests'
```

The regression failed before the guard was added during initial investigation.
No CI, publishing, acquisition-policy changes or unrelated handoff documents.