### PR TITLE
perf: reuse motorsport regexes with RSS benchmark evidence

### DIFF
--- a/src/Sportarr.Data/Services/EventPartDetector.cs
+++ b/src/Sportarr.Data/Services/EventPartDetector.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +22,16 @@ namespace Sportarr.Api.Services;
 public class EventPartDetector
 {
     private readonly ILogger<EventPartDetector> _logger;
+
+    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options, string Culture), Regex>
+        MotorsportRegexCache = new();
+
+    private static bool IsMotorsportMatch(string input, string pattern, RegexOptions options = RegexOptions.None)
+    {
+        var key = (pattern, options, CultureInfo.CurrentCulture.Name);
+        return MotorsportRegexCache.GetOrAdd(key,
+            static entry => new Regex(entry.Pattern, entry.Options)).IsMatch(input);
+    }
 
     /// <summary>
     /// UFC event types with different part structures
@@ -1172,7 +1184,7 @@ public class EventPartDetector
         {
             foreach (var pattern in session.Patterns)
             {
-                if (Regex.IsMatch(cleanTitle, pattern, RegexOptions.IgnoreCase))
+                if (IsMotorsportMatch(cleanTitle, pattern, RegexOptions.IgnoreCase))
                 {
                     return session.Name;
                 }
@@ -1258,7 +1270,7 @@ public class EventPartDetector
         // Exclude bonus/recap content and partial-day splits from session detection
         // e.g., "Ted's Sprint Race Notebook" contains "Sprint" but is NOT a Sprint session
         // e.g., "Test Two Day Two Morning" is a partial file — prefer full-day releases
-        if (Regex.IsMatch(cleanFilename, @"\b(notebook|ted'?s|highlights|review|analysis|preview|magazine|morning|afternoon)\b", RegexOptions.IgnoreCase))
+        if (IsMotorsportMatch(cleanFilename, @"\b(notebook|ted'?s|highlights|review|analysis|preview|magazine|morning|afternoon)\b", RegexOptions.IgnoreCase))
             return null;
 
         // Try all known motorsport session patterns (currently F1, but extensible)
@@ -1268,7 +1280,7 @@ public class EventPartDetector
             {
                 foreach (var pattern in session.Patterns)
                 {
-                    if (Regex.IsMatch(cleanFilename, pattern, RegexOptions.IgnoreCase))
+                    if (IsMotorsportMatch(cleanFilename, pattern, RegexOptions.IgnoreCase))
                     {
                         return session.Name;
                     }
@@ -1292,22 +1304,22 @@ public class EventPartDetector
         var lower = sessionName.ToLowerInvariant().Trim();
 
         // F1 Pre-season testing (most specific first) — matches "Testing 2 Day 3", "Test Two Day Three", etc.
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(3|three)")) return "Testing 2 Day 3";
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(2|two)")) return "Testing 2 Day 2";
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(1|one)")) return "Testing 2 Day 1";
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(3|three)")) return "Testing 1 Day 3";
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(2|two)")) return "Testing 1 Day 2";
-        if (Regex.IsMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(1|one)")) return "Testing 1 Day 1";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(3|three)")) return "Testing 2 Day 3";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(2|two)")) return "Testing 2 Day 2";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(2|two).*(day\s*)?(1|one)")) return "Testing 2 Day 1";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(3|three)")) return "Testing 1 Day 3";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(2|two)")) return "Testing 1 Day 2";
+        if (IsMotorsportMatch(lower, @"test(ing)?\s*(1|one).*(day\s*)?(1|one)")) return "Testing 1 Day 1";
 
         // MotoGP Shakedown tests (before generic tests)
-        if (lower.Contains("shakedown") && Regex.IsMatch(lower, @"(test|day)\s*(3|three)")) return "Shakedown Test 3";
-        if (lower.Contains("shakedown") && Regex.IsMatch(lower, @"(test|day)\s*(2|two)")) return "Shakedown Test 2";
-        if (lower.Contains("shakedown") && Regex.IsMatch(lower, @"(test|day)\s*(1|one)")) return "Shakedown Test 1";
+        if (lower.Contains("shakedown") && IsMotorsportMatch(lower, @"(test|day)\s*(3|three)")) return "Shakedown Test 3";
+        if (lower.Contains("shakedown") && IsMotorsportMatch(lower, @"(test|day)\s*(2|two)")) return "Shakedown Test 2";
+        if (lower.Contains("shakedown") && IsMotorsportMatch(lower, @"(test|day)\s*(1|one)")) return "Shakedown Test 1";
 
         // Generic tests
-        if (!lower.Contains("shakedown") && Regex.IsMatch(lower, @"\btest\s*(3|three)\b")) return "Test 3";
-        if (!lower.Contains("shakedown") && Regex.IsMatch(lower, @"\btest\s*(2|two)\b")) return "Test 2";
-        if (!lower.Contains("shakedown") && Regex.IsMatch(lower, @"\btest\s*(1|one)\b")) return "Test 1";
+        if (!lower.Contains("shakedown") && IsMotorsportMatch(lower, @"\btest\s*(3|three)\b")) return "Test 3";
+        if (!lower.Contains("shakedown") && IsMotorsportMatch(lower, @"\btest\s*(2|two)\b")) return "Test 2";
+        if (!lower.Contains("shakedown") && IsMotorsportMatch(lower, @"\btest\s*(1|one)\b")) return "Test 1";
 
         // Practice sessions - most specific first, bare "practice" falls through to Practice 1
         if (lower.Contains("practice 3") || lower.Contains("practice three") || lower.Contains("fp3") || lower.Contains("free practice 3"))
@@ -1329,9 +1341,9 @@ public class EventPartDetector
             return "Sprint";
 
         // Qualifying with number (specific before catch-all)
-        if (Regex.IsMatch(lower, @"qualif(ying|ier)\s*(1|one)") || lower == "q1")
+        if (IsMotorsportMatch(lower, @"qualif(ying|ier)\s*(1|one)") || lower == "q1")
             return "Qualifying 1";
-        if (Regex.IsMatch(lower, @"qualif(ying|ier)\s*(2|two)") || lower == "q2")
+        if (IsMotorsportMatch(lower, @"qualif(ying|ier)\s*(2|two)") || lower == "q2")
             return "Qualifying 2";
 
         // Qualifying catch-all (for combined Q1+Q2 releases or F1 single qualifying)

--- a/tests/RssMatchingBenchmark.md
+++ b/tests/RssMatchingBenchmark.md
@@ -1,0 +1,58 @@
+# RSS Matching Baseline
+
+`RssMatchingBenchmarkTests` calls the existing private `RssSyncService.FindMatchingEvent`
+method through a bound delegate. It exercises title parsing, per-event validation,
+and best-event selection without changing production visibility or implementing a
+second matching loop. A selector rename/signature change requires updating the binding.
+
+## Run
+
+From the repository root, run the small correctness case (20 releases, 71 events):
+
+```sh
+dotnet test tests/Sportarr.Api.Tests/Sportarr.Api.Tests.csproj -c Release -p:SkipFrontendBuild=true --filter FullyQualifiedName~RssMatchingBenchmarkTests --logger 'console;verbosity=detailed'
+```
+
+For the full 900-release, 71-event baseline on macOS/Linux:
+
+```sh
+SPORTARR_RSS_BENCHMARK=1 dotnet test tests/Sportarr.Api.Tests/Sportarr.Api.Tests.csproj -c Release -p:SkipFrontendBuild=true --filter FullyQualifiedName~RssMatchingBenchmarkTests --logger 'console;verbosity=detailed'
+```
+
+On PowerShell, set `$env:SPORTARR_RSS_BENCHMARK = '1'` before the same `dotnet test`
+command. Remove that variable afterward to restore the smaller default workload.
+Run in a fresh test process for comparisons, on the same hardware/build/runtime.
+Use the narrow filter above; the collection disables concurrent test collections.
+
+## Workload and Assertions
+
+- 71 synthetic monitored F1 session events, using fixed historical dates (not a real calendar).
+- 900 unique release titles in full mode, using ten repeating naming patterns with distinct groups.
+- 30% expected F1 matches, including country/demonym naming and quality variants.
+- 70% unrelated sport/TV/movie or wrong-year releases with no expected event.
+- 63,900 release/event comparisons per full pass; both passes assert all expected event IDs.
+- First and repeat passes share existing parser/normalization caches. "First" is not a
+  guaranteed cold-cache measurement if other matching tests ran in the process.
+- No timing threshold: the test gates correctness, while emitted measurements support
+  before/after comparisons without flaky machine-dependent assertions.
+
+## Initial Measurement
+
+Measured on macOS x64, .NET SDK 8.0.424/runtime 8.0.30, Release configuration,
+against upstream main `3cfbf7077`. One run, not a statistical benchmark:
+
+| Pass | Wall Time | Process CPU Time | Thread Allocated Bytes | Matches |
+| --- | ---: | ---: | ---: | ---: |
+| First | 62.451 s | 62.085 s | 28,332,635,688 | 270 |
+| Repeat | 57.991 s | 56.140 s | 28,279,910,752 | 270 |
+
+Allocated bytes are cumulative allocations on the synchronous matching thread,
+not retained heap size or peak memory. Process CPU includes runtime/GC work and
+any other activity in the test process. No forced garbage collection is performed.
+
+This is a selector workload, not the entire RSS sync: it excludes HTTP/feed parsing,
+database candidate queries, publication-age filtering, quality/upgrade decisions,
+pending releases, download submission, and production logging. The 900-by-71 shape
+matches the investigated workload size; the synthetic titles are not a production
+feed replay. These numbers do not establish individual method hotspots or predict
+ARM VPS timings. Capture managed CPU/allocation profiles before choosing an optimization.

--- a/tests/RssMatchingBenchmark.md
+++ b/tests/RssMatchingBenchmark.md
@@ -1,4 +1,4 @@
-# RSS Matching Baseline
+# RSS Matching Benchmark and Regex Reuse
 
 `RssMatchingBenchmarkTests` calls the existing private `RssSyncService.FindMatchingEvent`
 method through a bound delegate. It exercises title parsing, per-event validation,
@@ -54,5 +54,60 @@ This is a selector workload, not the entire RSS sync: it excludes HTTP/feed pars
 database candidate queries, publication-age filtering, quality/upgrade decisions,
 pending releases, download submission, and production logging. The 900-by-71 shape
 matches the investigated workload size; the synthetic titles are not a production
-feed replay. These numbers do not establish individual method hotspots or predict
-ARM VPS timings. Capture managed CPU/allocation profiles before choosing an optimization.
+feed replay. These numbers alone do not establish individual method hotspots or
+predict ARM VPS timings.
+
+## Root Cause and Fix
+
+An observed RSS pass processed about 900 releases against 71 events in 128 seconds,
+with Sportarr peaking near 208% process CPU on a four-core host. This motivated the
+synthetic workload; it does not prove that all production CPU had the same cause.
+
+Managed profiling (`dotnet-trace` 8.0.547301, CPU sampling plus CLR allocation ticks,
+analyzed with TraceEvent 3.1.21) attributed 80.8% of CPU samples and 92.7% of sampled
+allocation bytes to three motorsport session methods in `EventPartDetector`.
+Stacks showed repeated regex parsing/construction. Those methods cycle through
+more fixed patterns than the framework's default 15-entry static regex cache holds.
+Attribution used the nearest Sportarr service frame; sampled allocation estimates
+are not exact per-method counters, and inclusive CPU percentages are not additive.
+
+The fix reuses regex instances in a private concurrent cache keyed by pattern,
+options and culture. Only the three motorsport methods change. Pattern text,
+matching order, options and fallback behavior stay the same; the global framework
+cache is untouched. Keys come from internal literals/tables, never release titles.
+This is not a cache of matching decisions or database state.
+
+## Before and After
+
+Same macOS x64 host/runtime, Release build, untraced 900-by-71 workload:
+
+| Metric | Baseline First | Optimized First | Baseline Repeat | Optimized Repeat |
+| --- | ---: | ---: | ---: | ---: |
+| Wall time | 62.451 s | 12.171 s | 57.991 s | 9.741 s |
+| Process CPU | 62.085 s | 12.930 s | 56.140 s | 9.548 s |
+| Thread allocated bytes | 28,332,635,688 | 2,067,482,920 | 28,279,910,752 | 2,025,720,032 |
+| Expected matches | 270 | 270 | 270 | 270 |
+
+Approximately 5-6x faster and 93% fewer cumulative allocated bytes in these single
+measurements, not statistical confidence intervals or a production guarantee.
+The follow-up trace reduced filename-session detector allocation attribution from
+38.7 GB to 46.6 MB across both passes. Traced timings are not used in the table.
+
+## Regression Evidence
+
+- The independent upstream branch passed all five benchmark/cache tests, including
+  en-US, tr-TR and fr-FR culture switches and warm-cache allocation checks after
+  unrelated framework-cache churn. Full-workload rerun: first 12.5772s, repeat
+  9.1930s, 270 expected matches each; allocations about 2.067/2.026 GB.
+- Earlier broad matching/parser/session regressions passed 507 tests. The local
+  full suite had 11 macOS filesystem failures, reproduced on the unoptimized base.
+  Timing-sensitive failures also occurred during combined/emulated runs; isolated
+  reruns passed. No thresholds or tests were disabled in this change.
+- A combined fork build containing the import fix and this optimization passed
+  [1,912 tests on native ARM64](https://github.com/jasjeetsuri/Sportarr/actions/runs/34064382419)
+  plus image startup/restart checks. That is supporting combined-build evidence,
+  not a native run of this standalone branch or a same-host speedup comparison.
+
+Run the cache regression with the command above, replacing the filter with
+`FullyQualifiedName~MotorsportRegexReuseTests`. No CI, deployment, scheduler,
+acquisition-policy, or unrelated parser changes are included.

--- a/tests/Sportarr.Api.Tests/Services/MotorsportRegexReuseTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/MotorsportRegexReuseTests.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Sportarr.Api.Services;
+using Xunit.Abstractions;
+
+namespace Sportarr.Api.Tests.Services;
+
+[Collection("RSS matching measurements")]
+public class MotorsportRegexReuseTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void WarmDetection_DoesNotRebuildPatternsAfterGlobalCacheChurn()
+    {
+        const string filename = "Unrelated.Series.S01E01.1080p.WEB-GROUP";
+        const string eventTitle = "Monaco Grand Prix - Qualifying";
+        const string sessionName = "Testing 2 Day 3";
+        var originalCacheSize = Regex.CacheSize;
+
+        EventPartDetector.DetectMotorsportSessionFromFilename(filename).Should().BeNull();
+        EventPartDetector.DetectMotorsportSessionType(eventTitle, "Formula 1").Should().Be("Qualifying");
+        EventPartDetector.NormalizeMotorsportSession(sessionName).Should().Be(sessionName);
+
+        long allocated = 0;
+        for (var iteration = 0; iteration < 20; iteration++)
+        {
+            for (var patternIndex = 0; patternIndex < originalCacheSize + 1; patternIndex++)
+                Regex.IsMatch("unrelated", $"^unrelated{patternIndex}$");
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var releaseSession = EventPartDetector.DetectMotorsportSessionFromFilename(filename);
+            var eventSession = EventPartDetector.DetectMotorsportSessionType(eventTitle, "Formula 1");
+            var normalized = EventPartDetector.NormalizeMotorsportSession(sessionName);
+            allocated += GC.GetAllocatedBytesForCurrentThread() - before;
+
+            releaseSession.Should().BeNull();
+            eventSession.Should().Be("Qualifying");
+            normalized.Should().Be(sessionName);
+        }
+
+        output.WriteLine($"Warm detector allocation across 20 cache-churn iterations: {allocated:N0} bytes");
+        allocated.Should().BeLessThan(128 * 1024,
+            "fixed regexes must survive unrelated use of the global regex cache");
+        Regex.CacheSize.Should().Be(originalCacheSize);
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("tr-TR")]
+    [InlineData("fr-FR")]
+    public void Detection_RemainsStableAcrossCultureChanges(string cultureName)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            foreach (var culture in new[] { "en-US", cultureName, "en-US" })
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+                EventPartDetector.DetectMotorsportSessionFromFilename("Formula1.2024.Monaco.Sprint.Qualifying")
+                    .Should().Be("Sprint Qualifying");
+                EventPartDetector.DetectMotorsportSessionType("Monaco Grand Prix - Practice 2", "Formula 1")
+                    .Should().Be("Practice 2");
+                EventPartDetector.NormalizeMotorsportSession("Test Two Day Three")
+                    .Should().Be("Testing 2 Day 3");
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/tests/Sportarr.Api.Tests/Services/RssMatchingBenchmarkTests.cs
+++ b/tests/Sportarr.Api.Tests/Services/RssMatchingBenchmarkTests.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sportarr.Api.Models;
+using Sportarr.Api.Services;
+using Xunit.Abstractions;
+
+namespace Sportarr.Api.Tests.Services;
+
+[CollectionDefinition("RSS matching measurements", DisableParallelization = true)]
+public class RssMatchingMeasurementCollection;
+
+[Collection("RSS matching measurements")]
+public class RssMatchingBenchmarkTests(ITestOutputHelper output)
+{
+    private delegate Event? FindMatch(ReleaseSearchResult release, List<Event> events,
+        ReleaseMatchingService matcher, bool multiPart, IReadOnlyDictionary<int, int?> earlyLimits);
+
+    [Fact]
+    public void MixedFeed_SelectsExpectedEvents_OnFirstAndRepeatPass()
+    {
+        var fullSize = Environment.GetEnvironmentVariable("SPORTARR_RSS_BENCHMARK") == "1";
+        var events = CreateEvents();
+        var releases = CreateReleases(fullSize ? 900 : 20);
+        using var services = new ServiceCollection().BuildServiceProvider();
+        using var rss = new RssSyncService(services, NullLogger<RssSyncService>.Instance);
+        var matcher = new ReleaseMatchingService(NullLogger<ReleaseMatchingService>.Instance,
+            new SportsFileNameParser(NullLogger<SportsFileNameParser>.Instance),
+            new EventPartDetector(NullLogger<EventPartDetector>.Instance));
+        var findMatch = typeof(RssSyncService).GetMethod("FindMatchingEvent",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.CreateDelegate<FindMatch>(rss);
+        var earlyLimits = new Dictionary<int, int?>();
+
+        output.WriteLine($"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}; " +
+            $"OS: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}; " +
+            $"architecture: {System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture}");
+        output.WriteLine($"Releases: {releases.Count}; events: {events.Count}; pairs/pass: {releases.Count * events.Count}");
+
+        var first = Measure("first", findMatch, releases, events, matcher, earlyLimits);
+        var repeat = Measure("repeat", findMatch, releases, events, matcher, earlyLimits);
+
+        first.Should().Equal(releases.Select(release => release.ExpectedId));
+        repeat.Should().Equal(first);
+    }
+
+    private int?[] Measure(string pass, FindMatch findMatch,
+        List<(ReleaseSearchResult Release, int? ExpectedId)> releases, List<Event> events,
+        ReleaseMatchingService matcher, IReadOnlyDictionary<int, int?> earlyLimits)
+    {
+        using var process = Process.GetCurrentProcess();
+        var results = new int?[releases.Count];
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var cpuBefore = process.TotalProcessorTime;
+        var timer = Stopwatch.StartNew();
+        for (var index = 0; index < releases.Count; index++)
+        {
+            results[index] = findMatch(releases[index].Release, events, matcher, true, earlyLimits)?.Id;
+        }
+        timer.Stop();
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        var cpu = process.TotalProcessorTime - cpuBefore;
+        output.WriteLine($"{pass}: elapsed={timer.Elapsed.TotalMilliseconds:F1} ms; " +
+            $"process CPU={cpu.TotalMilliseconds:F1} ms; thread allocations={allocated:N0} bytes; " +
+            $"matches={results.Count(result => result.HasValue)}");
+        return results;
+    }
+
+    private static List<Event> CreateEvents()
+    {
+        var venues = new[]
+        {
+            ("China", "Chinese"), ("Canada", "Canadian"), ("Bahrain", "Bahrain"),
+            ("Australia", "Australian"), ("Japan", "Japanese"), ("Miami", "Miami"),
+            ("Monaco", "Monaco"), ("Spain", "Spanish"), ("Austria", "Austrian"),
+            ("Britain", "British"), ("Hungary", "Hungarian"), ("Belgium", "Belgian"),
+            ("Netherlands", "Dutch"), ("Italy", "Italian"), ("Azerbaijan", "Azerbaijan"),
+            ("Singapore", "Singapore"), ("Mexico", "Mexican"), ("Brazil", "Brazilian"),
+            ("Qatar", "Qatar"), ("Abu Dhabi", "Abu Dhabi"), ("Las Vegas", "Las Vegas"),
+            ("Saudi Arabia", "Saudi Arabian"), ("United States", "United States")
+        };
+        var league = new League { Id = 1, Name = "Formula 1", Sport = "Motorsport" };
+        var events = new List<Event>();
+        foreach (var (location, adjective) in venues)
+        {
+            foreach (var session in new[] { "Practice 1", "Qualifying", "Race" })
+            {
+                events.Add(new Event
+                {
+                    Id = events.Count + 1, Title = $"{adjective} Grand Prix - {session}",
+                    Sport = "Motorsport", League = league, LeagueId = league.Id,
+                    Location = location, Season = "2024", Monitored = true,
+                    EventDate = new DateTime(2024, 3, 1, 12, 0, 0, DateTimeKind.Utc).AddDays(events.Count)
+                });
+            }
+        }
+        foreach (var session in new[] { "Practice 2", "Practice 3" })
+        {
+            events.Add(new Event
+            {
+                Id = events.Count + 1, Title = $"Bahrain Grand Prix - {session}",
+                Sport = "Motorsport", League = league, LeagueId = league.Id,
+                Location = "Bahrain", Season = "2024", Monitored = true,
+                EventDate = new DateTime(2024, 3, 2, 12, 0, 0, DateTimeKind.Utc)
+            });
+        }
+        return events;
+    }
+
+    private static List<(ReleaseSearchResult Release, int? ExpectedId)> CreateReleases(int count)
+    {
+        var samples = new (string Title, int? ExpectedId)[]
+        {
+            ("Formula1.2024.China.Grand.Prix.Qualifying.1080p.WEB.h264", 2),
+            ("Formula1.2024.Canada.Grand.Prix.Race.2160p.WEB.h265", 6),
+            ("NBA.2024.03.02.Lakers.vs.Celtics.1080p.WEB.h264", null),
+            ("NHL.2024.03.02.Bruins.vs.Canadiens.720p.WEB.h264", null),
+            ("UFC.299.Main.Card.1080p.WEB.h264", null),
+            ("MotoGP.2024.Qatar.Race.1080p.WEB.h264", null),
+            ("The.Example.Show.S02E03.1080p.WEB.h264", null),
+            ("Example.Movie.2024.1080p.BluRay.x264", null),
+            ("Formula1.2023.China.Grand.Prix.Qualifying.1080p.WEB.h264", null),
+            ("Formula1.2024.Canada.Grand.Prix.Race.720p.WEB.h264", 6)
+        };
+        return Enumerable.Range(0, count).Select(index =>
+        {
+            var sample = samples[index % samples.Length];
+            return (new ReleaseSearchResult
+            {
+                Title = $"{sample.Title}-BENCH{index:D4}", Guid = $"benchmark-{index}",
+                DownloadUrl = $"https://example.invalid/releases/{index}", Indexer = "Synthetic"
+            }, sample.ExpectedId);
+        }).ToList();
+    }
+}


### PR DESCRIPTION
## Issue and Analysis

An investigated RSS pass matched about 900 releases against 71 events in 128s,
peaking near 208% process CPU on a four-core host. A synthetic selector benchmark
reproduced heavy regex allocation without live feeds, clients or database work.

Managed profiling attributed 80.8% of CPU samples and 92.7% of sampled allocation
bytes to three motorsport session methods in `EventPartDetector`. These cycle
through more fixed regex patterns than the framework's default 15-entry static
cache, causing repeated parsing/construction. Attribution and measurement limits
are documented in `tests/RssMatchingBenchmark.md`.

## Fix

Reuse regex instances in a private concurrent cache keyed by pattern, options and
culture, only in those three methods. Pattern text/order/options/fallbacks remain
unchanged. Keys are internal patterns, not release titles; no matching decisions
are cached and the framework global cache is untouched.

## Benchmark

Same macOS x64 host, .NET 8.0.30, Release, 900 synthetic releases x 71 events:

| Metric | Before first/repeat | After first/repeat |
| --- | --- | --- |
| Elapsed | 62.451 / 57.991 s | 12.171 / 9.741 s |
| Process CPU | 62.085 / 56.140 s | 12.930 / 9.548 s |
| Cumulative thread allocations | 28.333 / 28.280 GB | 2.067 / 2.026 GB |
| Expected matches | 270 / 270 | 270 / 270 |

Approximately 5-6x faster and 93% fewer cumulative allocations in these runs.
Not retained memory, a production-feed replay, statistical confidence intervals,
or a guaranteed VPS speedup. The document includes the full reproduction command.

## Validation and Scope

- This independent branch: 5/5 benchmark/cache tests passed, including culture
  switches and warm allocations after global-cache churn. Full rerun: 12.5772 /
  9.1930s; all expected event IDs matched on both passes.
- Earlier broad matching/parser/session run: 507 passed. Native ARM64 combined-fork
  build: [1,912 passed and image smoke passed](https://github.com/jasjeetsuri/Sportarr/actions/runs/34064382419).
  That native evidence includes the separate import fix, not this exact branch.
- Local full-suite filesystem failures reproduced on baseline; timing-sensitive
  combined/emulated failures are disclosed in the benchmark note. No thresholds changed.

Four files only: detector, benchmark fixture, cache regression fixture, and one
evidence/reproduction note. Benchmark and optimization are separate commits for
before/after reproduction. No import fix, policy, CI or publishing dependencies.